### PR TITLE
Add ToI420 converter

### DIFF
--- a/pkg/codec/openh264/openh264.go
+++ b/pkg/codec/openh264/openh264.go
@@ -49,7 +49,7 @@ func NewEncoder(r video.Reader, p prop.Video) (io.ReadCloser, error) {
 
 	return &encoder{
 		engine: cEncoder,
-		r:      r,
+		r:      video.ToI420(r),
 	}, nil
 }
 
@@ -68,8 +68,6 @@ func (e *encoder) Read(p []byte) (n int, err error) {
 		return 0, err
 	}
 
-	// TODO: Convert img to YCbCr since openh264 only accepts YCbCr
-	// TODO: Convert img to 4:2:0 format which what openh264 accepts
 	yuvImg := img.(*image.YCbCr)
 	bounds := yuvImg.Bounds()
 	s, err := C.enc_encode(e.engine, C.Frame{

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -98,7 +98,7 @@ func newEncoder(r video.Reader, p prop.Video, codecIface *C.vpx_codec_iface_t) (
 		return nil, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
 	}
 	return &encoder{
-		r:                r,
+		r:                video.ToI420(r),
 		codec:            codec,
 		raw:              rawNoBuffer,
 		keyframeInterval: 30, // TODO: Set via prop.Video
@@ -123,40 +123,6 @@ func (e *encoder) Read(p []byte) (int, error) {
 	e.raw.stride[0] = C.int(yuvImg.YStride)
 	e.raw.stride[1] = C.int(yuvImg.CStride)
 	e.raw.stride[2] = C.int(yuvImg.CStride)
-	h := yuvImg.Rect.Max.Y - yuvImg.Rect.Min.Y
-
-	// Covert pixel format to I420
-	// TODO: maybe better to move it to a proper module
-	switch yuvImg.SubsampleRatio {
-	case image.YCbCrSubsampleRatio444:
-		for i := 0; i < h/2; i++ {
-			addrSrc := i * 2 * yuvImg.CStride
-			addrDst := i * yuvImg.CStride / 2
-			for j := 0; j < yuvImg.CStride/2; j++ {
-				cb := uint16(yuvImg.Cb[addrSrc+j]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j]) +
-					uint16(yuvImg.Cb[addrSrc+j+1]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j+1])
-				cr := uint16(yuvImg.Cr[addrSrc+j]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j]) +
-					uint16(yuvImg.Cr[addrSrc+j+1]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j+1])
-				yuvImg.Cb[addrDst+j] = uint8(cb / 4)
-				yuvImg.Cr[addrDst+j] = uint8(cr / 4)
-			}
-		}
-		yuvImg.CStride = yuvImg.CStride / 2
-	case image.YCbCrSubsampleRatio422:
-		for i := 0; i < h/2; i++ {
-			addrSrc := i * 2 * yuvImg.CStride
-			addrDst := i * yuvImg.CStride
-			for j := 0; j < yuvImg.CStride; j++ {
-				cb := uint16(yuvImg.Cb[addrSrc+j]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j])
-				cr := uint16(yuvImg.Cr[addrSrc+j]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j])
-				yuvImg.Cb[addrDst+j] = uint8(cb / 2)
-				yuvImg.Cr[addrDst+j] = uint8(cr / 2)
-			}
-		}
-	case image.YCbCrSubsampleRatio420:
-	default:
-		return 0, fmt.Errorf("unsupported pixel format: %s", yuvImg.SubsampleRatio)
-	}
 
 	var flags int
 	if e.frameIndex%e.keyframeInterval == 0 {

--- a/pkg/io/video/convert.go
+++ b/pkg/io/video/convert.go
@@ -1,0 +1,54 @@
+package video
+
+import (
+	"fmt"
+	"image"
+)
+
+// ToI420 converts r to a new reader that will output images in I420 format
+func ToI420(r Reader) Reader {
+	return ReaderFunc(func() (image.Image, error) {
+		img, err := r.Read()
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: Not sure how to handle this when it's not YCbCr, maybe try to convert it to YCvCr?
+		yuvImg := img.(*image.YCbCr)
+		h := yuvImg.Rect.Max.Y - yuvImg.Rect.Min.Y
+
+		// Covert pixel format to I420
+		switch yuvImg.SubsampleRatio {
+		case image.YCbCrSubsampleRatio444:
+			for i := 0; i < h/2; i++ {
+				addrSrc := i * 2 * yuvImg.CStride
+				addrDst := i * yuvImg.CStride / 2
+				for j := 0; j < yuvImg.CStride/2; j++ {
+					cb := uint16(yuvImg.Cb[addrSrc+j]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j]) +
+						uint16(yuvImg.Cb[addrSrc+j+1]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j+1])
+					cr := uint16(yuvImg.Cr[addrSrc+j]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j]) +
+						uint16(yuvImg.Cr[addrSrc+j+1]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j+1])
+					yuvImg.Cb[addrDst+j] = uint8(cb / 4)
+					yuvImg.Cr[addrDst+j] = uint8(cr / 4)
+				}
+			}
+			yuvImg.CStride = yuvImg.CStride / 2
+		case image.YCbCrSubsampleRatio422:
+			for i := 0; i < h/2; i++ {
+				addrSrc := i * 2 * yuvImg.CStride
+				addrDst := i * yuvImg.CStride
+				for j := 0; j < yuvImg.CStride; j++ {
+					cb := uint16(yuvImg.Cb[addrSrc+j]) + uint16(yuvImg.Cb[addrSrc+yuvImg.CStride+j])
+					cr := uint16(yuvImg.Cr[addrSrc+j]) + uint16(yuvImg.Cr[addrSrc+yuvImg.CStride+j])
+					yuvImg.Cb[addrDst+j] = uint8(cb / 2)
+					yuvImg.Cr[addrDst+j] = uint8(cr / 2)
+				}
+			}
+		case image.YCbCrSubsampleRatio420:
+		default:
+			return nil, fmt.Errorf("unsupported pixel format: %s", yuvImg.SubsampleRatio)
+		}
+
+		return yuvImg, nil
+	})
+}


### PR DESCRIPTION
Moved I420 converter from vpx.go, converted `video.Reader` in openh264.go, and created ToI420 to convert a `video.Reader` to a new `video.Reader` that will emit images in I420 format.
