### PR TITLE
Add OnEnded handler

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -66,7 +66,12 @@ func main() {
 	}
 
 	for _, tracker := range s.GetTracks() {
-		_, err = peerConnection.AddTrack(tracker.Track())
+		t := tracker.Track()
+		tracker.OnEnded(func(err error) {
+			fmt.Printf("Track (ID: %s, Label: %s) ended with error: %v\n",
+				t.ID(), t.Label(), err)
+		})
+		_, err = peerConnection.AddTrack(t)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
In Web API, `MediaStreamTrack.ended` event is fired and
`MediaStreamTrack.onended` handler is called on device error.
This commit adds same way to handle errors.

### Reference issue
Fixes #18
