### PR TITLE
Move Codec from MediaTrackConstraints to prop.Codec

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -50,12 +50,12 @@ func main() {
 
 	s, err := md.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Audio: func(c *mediadevices.MediaTrackConstraints) {
-			c.Codec = webrtc.Opus
+			c.CodecName = webrtc.Opus
 			c.Enabled = true
 			c.BitRate = 32000 // 32kbps
 		},
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.Codec = videoCodecName
+			c.CodecName = videoCodecName
 			c.FrameFormat = frame.FormatI420 // most of the encoder accepts I420
 			c.Enabled = true
 			c.Width = 640

--- a/mediadevices.go
+++ b/mediadevices.go
@@ -132,10 +132,11 @@ func selectBestDriver(filter driver.FilterFn, constraints MediaTrackConstraints)
 		return nil, MediaTrackConstraints{}, fmt.Errorf("failed to find the best driver that fits the constraints")
 	}
 
+	// Reset Codec because bestProp only contains either audio.Prop or video.Prop
+	bestProp.Codec = constraints.Codec
 	bestConstraint := MediaTrackConstraints{
 		Media:   bestProp,
 		Enabled: true,
-		Codec:   constraints.Codec,
 	}
 	return bestDriver, bestConstraint, nil
 }

--- a/mediastreamconstraints.go
+++ b/mediastreamconstraints.go
@@ -13,7 +13,6 @@ type MediaStreamConstraints struct {
 type MediaTrackConstraints struct {
 	prop.Media
 	Enabled bool
-	Codec   string
 }
 
 type MediaOption func(*MediaTrackConstraints)

--- a/pkg/codec/registrar.go
+++ b/pkg/codec/registrar.go
@@ -23,19 +23,19 @@ func Register(name string, builder interface{}) {
 	}
 }
 
-func BuildVideoEncoder(name string, r video.Reader, p prop.Media) (io.ReadCloser, error) {
-	b, ok := videoEncoders[name]
+func BuildVideoEncoder(r video.Reader, p prop.Media) (io.ReadCloser, error) {
+	b, ok := videoEncoders[p.CodecName]
 	if !ok {
-		return nil, fmt.Errorf("codec: can't find %s video encoder", name)
+		return nil, fmt.Errorf("codec: can't find %s video encoder", p.CodecName)
 	}
 
 	return b(r, p)
 }
 
-func BuildAudioEncoder(name string, r audio.Reader, p prop.Media) (io.ReadCloser, error) {
-	b, ok := audioEncoders[name]
+func BuildAudioEncoder(r audio.Reader, p prop.Media) (io.ReadCloser, error) {
+	b, ok := audioEncoders[p.CodecName]
 	if !ok {
-		return nil, fmt.Errorf("codec: can't find %s audio encoder", name)
+		return nil, fmt.Errorf("codec: can't find %s audio encoder", p.CodecName)
 	}
 
 	return b(r, p)

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -75,6 +75,8 @@ type Audio struct {
 
 // Codec represents an codec's encoding properties
 type Codec struct {
+	CodecName string
+
 	// Target bitrate in bps.
 	BitRate int
 

--- a/track.go
+++ b/track.go
@@ -82,7 +82,7 @@ type videoTrack struct {
 var _ Tracker = &videoTrack{}
 
 func newVideoTrack(codecs []*webrtc.RTPCodec, d driver.Driver, constraints MediaTrackConstraints) (*videoTrack, error) {
-	codecName := constraints.Codec
+	codecName := constraints.CodecName
 	t, err := newTrack(codecs, d, codecName)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func newVideoTrack(codecs []*webrtc.RTPCodec, d driver.Driver, constraints Media
 		return nil, err
 	}
 
-	encoder, err := codec.BuildVideoEncoder(codecName, r, constraints.Media)
+	encoder, err := codec.BuildVideoEncoder(r, constraints.Media)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ type audioTrack struct {
 var _ Tracker = &audioTrack{}
 
 func newAudioTrack(codecs []*webrtc.RTPCodec, d driver.Driver, constraints MediaTrackConstraints) (*audioTrack, error) {
-	codecName := constraints.Codec
+	codecName := constraints.CodecName
 	t, err := newTrack(codecs, d, codecName)
 	if err != nil {
 		return nil, err
@@ -170,7 +170,7 @@ func newAudioTrack(codecs []*webrtc.RTPCodec, d driver.Driver, constraints Media
 		return nil, err
 	}
 
-	encoder, err := codec.BuildAudioEncoder(codecName, reader, constraints.Media)
+	encoder, err := codec.BuildAudioEncoder(reader, constraints.Media)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description
It feels weird to put `Codec` under `MediaTrackConstraints`. Figured that it makes to put it under `prop.Codec` instead.