### PR TITLE
Stop video track safely

### DIFF
--- a/pkg/driver/camera/camera_bench_test.go
+++ b/pkg/driver/camera/camera_bench_test.go
@@ -53,13 +53,6 @@ func BenchmarkRead(b *testing.B) {
 			if err != nil {
 				b.Skipf("Failed to capture image: %v", err)
 			}
-			defer func() {
-				if r != nil {
-					go func() {
-						_, _ = r.Read() // Workaround for deadlock
-					}()
-				}
-			}()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/pkg/driver/camera/camera_bench_test.go
+++ b/pkg/driver/camera/camera_bench_test.go
@@ -1,0 +1,74 @@
+// +build cpuusage
+
+// This is not an actual benchmark test.
+// Please manually check the CPU usage during the test.
+// $ go test -bench . -tags cpuusage -benchtime 10s -benchmem
+
+package camera
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+func BenchmarkRead(b *testing.B) {
+	c := newCamera("/dev/video0")
+
+	props := map[string]prop.Media{
+		"480p": prop.Media{
+			Video: prop.Video{
+				Width:       640,
+				Height:      480,
+				FrameFormat: frame.FormatYUYV,
+			},
+		},
+		"720p": prop.Media{
+			Video: prop.Video{
+				Width:       1280,
+				Height:      720,
+				FrameFormat: frame.FormatYUYV,
+			},
+		},
+		"1080p": prop.Media{
+			Video: prop.Video{
+				Width:       1920,
+				Height:      1080,
+				FrameFormat: frame.FormatYUYV,
+			},
+		},
+	}
+	for name, p := range props {
+		time.Sleep(500 * time.Millisecond)
+		p := p
+		b.Run(name, func(b *testing.B) {
+			if err := c.Open(); err != nil {
+				b.Skip("You don't have camera.")
+			}
+			defer c.Close()
+
+			r, err := c.VideoRecord(p)
+			if err != nil {
+				b.Skipf("Failed to capture image: %v", err)
+			}
+			defer func() {
+				if r != nil {
+					go func() {
+						_, _ = r.Read() // Workaround for deadlock
+					}()
+				}
+			}()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := r.Read()
+				if err != nil {
+					b.Fatalf("Failed to read: %v", err)
+				}
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -4,11 +4,12 @@ package camera
 import "C"
 
 import (
+	"context"
 	"errors"
 	"image"
 	"io"
 	"io/ioutil"
-	"sync/atomic"
+	"sync"
 
 	"github.com/blackjack/webcam"
 	"github.com/pion/mediadevices/pkg/driver"
@@ -34,7 +35,8 @@ type camera struct {
 	formats         map[webcam.PixelFormat]frame.Format
 	reversedFormats map[frame.Format]webcam.PixelFormat
 	started         bool
-	closed          atomic.Value // bool
+	wg              *sync.WaitGroup
+	cancel          func()
 }
 
 func init() {
@@ -67,7 +69,6 @@ func newCamera(path string) *camera {
 		formats:         formats,
 		reversedFormats: reversedFormats,
 	}
-	c.closed.Store(false)
 	return c
 }
 
@@ -78,7 +79,6 @@ func (c *camera) Open() error {
 	}
 
 	c.cam = cam
-	c.closed.Store(false)
 	return nil
 }
 
@@ -87,14 +87,19 @@ func (c *camera) Close() error {
 		return nil
 	}
 
-	if c.started {
+	if c.cancel != nil {
+		// Let the reader knows that the caller has closed the camera
+		c.cancel()
+		// Wait until the reader receives the cancelation
+		c.wg.Wait()
+
 		// Note: StopStreaming frees frame buffers even if they are still used in Go code.
 		//       There is currently no convenient way to do this safely.
 		//       So, consumer of this stream must close camera after unusing all images.
 		c.cam.StopStreaming()
+		c.cancel = nil
 	}
 	c.cam.Close()
-	c.closed.Store(true)
 	return nil
 }
 
@@ -113,12 +118,17 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 	if err := c.cam.StartStreaming(); err != nil {
 		return nil, err
 	}
-	c.started = true
 
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	c.wg = &sync.WaitGroup{}
+	c.wg.Add(1)
+	var buf []byte
 	r := video.ReaderFunc(func() (img image.Image, err error) {
 		// Wait until a frame is ready
 		for i := 0; i < maxEmptyFrameCount; i++ {
-			if c.closed.Load().(bool) {
+			if ctx.Err() != nil {
+				c.wg.Done()
 				// Return EOF if the camera is already closed.
 				return nil, io.EOF
 			}
@@ -145,7 +155,16 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 				continue
 			}
 
-			return decoder.Decode(b, p.Width, p.Height)
+			if len(b) > len(buf) {
+				// Grow the intermediate buffer
+				buf = make([]byte, len(b))
+			}
+
+			// move the memory from mmap to Go. This will guarantee that any data that's going out
+			// from this reader will be Go safe. Otherwise, it's possible that outside of this reader
+			// that this memory is still being used even after we close it.
+			n := copy(buf, b)
+			return decoder.Decode(buf[:n], p.Width, p.Height)
 		}
 		return nil, errEmptyFrame
 	})

--- a/track.go
+++ b/track.go
@@ -1,9 +1,11 @@
 package mediadevices
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 
 	"github.com/pion/mediadevices/pkg/codec"
@@ -82,6 +84,8 @@ type videoTrack struct {
 	d           driver.Driver
 	constraints MediaTrackConstraints
 	encoder     io.ReadCloser
+	wg          *sync.WaitGroup
+	cancel      func()
 }
 
 var _ Tracker = &videoTrack{}
@@ -113,22 +117,34 @@ func newVideoTrack(opts *MediaDevicesOptions, d driver.Driver, constraints Media
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	vt := videoTrack{
 		track:       t,
 		d:           d,
 		constraints: constraints,
 		encoder:     encoder,
+		wg:          &sync.WaitGroup{},
+		cancel:      cancel,
 	}
 
-	go vt.start()
+	vt.wg.Add(1)
+	go func() {
+		vt.start(ctx)
+		vt.wg.Done()
+		cancel()
+	}()
 	return &vt, nil
 }
 
-func (vt *videoTrack) start() {
+func (vt *videoTrack) start(ctx context.Context) {
 	var n int
 	var err error
 	buff := make([]byte, 1024)
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		n, err = vt.encoder.Read(buff)
 		if err != nil {
 			if e, ok := err.(*mio.InsufficientBufferError); ok {
@@ -148,6 +164,11 @@ func (vt *videoTrack) start() {
 }
 
 func (vt *videoTrack) Stop() {
+	// Wait finishing video read loop to avoid memory violation
+	// as the video frames might be alloced by C or on shared memory.
+	vt.cancel()
+	vt.wg.Wait()
+
 	vt.d.Close()
 	vt.encoder.Close()
 }


### PR DESCRIPTION
Treat camera read timeout as error and return detailed errors.
Wait finishing video read loop to avoid memory violation
as the video frames might be alloced by C or on shared memory.

### Reference issue
https://github.com/pion/mediadevices/issues/35#issuecomment-584535022
