### PR TITLE
Allow to use user defined Track

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -3,17 +3,16 @@ package mediadevices
 import (
 	"time"
 
-	"github.com/pion/webrtc/v2"
 	"github.com/pion/webrtc/v2/pkg/media"
 )
 
 type sampler struct {
-	track         *webrtc.Track
+	track         LocalTrack
 	clockRate     float64
 	lastTimestamp time.Time
 }
 
-func newSampler(track *webrtc.Track) *sampler {
+func newSampler(track LocalTrack) *sampler {
 	return &sampler{
 		track:         track,
 		clockRate:     float64(track.Codec().ClockRate),


### PR DESCRIPTION
Add WithTrackGenerator option to specify TrackGenerator.
This allows user to replace Track by user defined one that
has WriteSample() and Codec() interface.

So that we can get encoded media streams directly from MediaDevices.