### PR TITLE
Add CGO version of color convert

### DIFF
--- a/pkg/io/video/convert_cgo.c
+++ b/pkg/io/video/convert_cgo.c
@@ -54,3 +54,118 @@ void i422ToI420CGO(
     isrc += stride;
   }
 }
+
+void rgbToYCbCrCGO(
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char r,
+    const unsigned char g,
+    const unsigned char b)
+{
+  // ITU-R BT.601
+  const int y2 = 77 * r + 150 * g + 29 * b;
+  const int cb2 = -43 * r - 85 * g + 128 * b + 0x8000;
+  const int cr2 = 128 * r - 107 * g - 21 * b + 0x8000;
+
+  *y = y2 >> 8;
+  *cb = cb2 >> 8;
+  *cr = cr2 >> 8;
+}
+
+void repeatRGBToYCbCrCGO(
+    const int n,
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char r,
+    const unsigned char g,
+    const unsigned char b)
+{
+  int i;
+  for (i = 0; i < n; ++i)
+  {
+    rgbToYCbCrCGO(y, cb, cr, r, g, b);
+  }
+}
+
+void yCbCrToRGBCGO(
+    unsigned char* r,
+    unsigned char* g,
+    unsigned char* b,
+    const unsigned char y,
+    const unsigned char cb,
+    const unsigned char cr)
+{
+  const int cb2 = cb - 0x80;
+  const int cr2 = cr - 0x80;
+
+  // ITU-R BT.601
+  int r2 = 256 * y + 359 * cr2;
+  int g2 = 256 * y - 88 * cb2 - 183 * cr2;
+  int b2 = 256 * y + 454 * cb2;
+
+  if (r2 < 0)
+    r2 = 0;
+  else if (r2 > 0xFFFF)
+    r2 = 0xFFFF;
+  if (g2 < 0)
+    g2 = 0;
+  else if (g2 > 0xFFFF)
+    g2 = 0xFFFF;
+  if (b2 < 0)
+    b2 = 0;
+  else if (b2 > 0xFFFF)
+    b2 = 0xFFFF;
+
+  *r = r2 >> 8;
+  *g = g2 >> 8;
+  *b = b2 >> 8;
+}
+
+void repeatYCbCrToRGBCGO(
+    const int n,
+    unsigned char* r,
+    unsigned char* g,
+    unsigned char* b,
+    const unsigned char y,
+    const unsigned char cb,
+    const unsigned char cr)
+{
+  int i;
+  for (i = 0; i < n; ++i)
+  {
+    yCbCrToRGBCGO(r, g, b, y, cb, cr);
+  }
+}
+
+void i444ToRGBACGO(
+    unsigned char* rgb,
+    const unsigned char* y,
+    const unsigned char* cb,
+    const unsigned char* cr,
+    const int stride, const int h)
+{
+  int i;
+  for (i = 0; i < stride * h; ++i)
+  {
+    yCbCrToRGBCGO(rgb, rgb + 1, rgb + 2, y[i], cb[i], cr[i]);
+    rgb[3] = 0xFF;
+    rgb += 4;
+  }
+}
+
+void rgbaToI444(
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char* rgb,
+    const int stride, const int h)
+{
+  int i;
+  for (i = 0; i < stride * h; ++i)
+  {
+    rgbToYCbCrCGO(&y[i], &cb[i], &cr[i], rgb[0], rgb[1], rgb[2]);
+    rgb += 4;
+  }
+}

--- a/pkg/io/video/convert_cgo.c
+++ b/pkg/io/video/convert_cgo.c
@@ -1,0 +1,56 @@
+#include <stdint.h>
+
+#include "_cgo_export.h"
+
+void i444ToI420CGO(
+    unsigned char* cb,
+    unsigned char* cr,
+    const int stride, const int h)
+{
+  int isrc0 = 0;
+  int isrc1 = stride;
+  int idst = 0;
+  for (int y = 0; y < h / 2; y++)
+  {
+    for (int x = 0; x < stride / 2; x++)
+    {
+      const uint8_t cb2 =
+          ((uint16_t)cb[isrc0] + (uint16_t)cb[isrc1] +
+           (uint16_t)cb[isrc0 + 1] + (uint16_t)cb[isrc1 + 1]) /
+          4;
+      const uint8_t cr2 =
+          ((uint16_t)cr[isrc0] + (uint16_t)cr[isrc1] +
+           (uint16_t)cr[isrc0 + 1] + (uint16_t)cr[isrc1 + 1]) /
+          4;
+      cb[idst] = cb2;
+      cr[idst] = cr2;
+      isrc0 += 2;
+      isrc1 += 2;
+      idst++;
+    }
+    isrc0 += stride;
+    isrc1 += stride;
+  }
+}
+
+void i422ToI420CGO(
+    unsigned char* cb,
+    unsigned char* cr,
+    const int stride, const int h)
+{
+  int isrc = 0;
+  int idst = 0;
+  for (int y = 0; y < h / 2; y++)
+  {
+    for (int x = 0; x < stride; x++)
+    {
+      const uint8_t cb2 = ((uint16_t)cb[isrc] + (uint16_t)cb[isrc + stride]) / 2;
+      const uint8_t cr2 = ((uint16_t)cr[isrc] + (uint16_t)cr[isrc + stride]) / 2;
+      cb[idst] = cb2;
+      cr[idst] = cr2;
+      isrc++;
+      idst++;
+    }
+    isrc += stride;
+  }
+}

--- a/pkg/io/video/convert_cgo.go
+++ b/pkg/io/video/convert_cgo.go
@@ -6,12 +6,7 @@ import (
 	"image"
 )
 
-// void i444ToI420CGO(
-//     unsigned char* cb, unsigned char* cr,
-//     const int stride, const int h);
-// void i422ToI420CGO(
-//     unsigned char* cb, unsigned char* cr,
-//     const int stride, const int h);
+// #include "convert_cgo.h"
 import "C"
 
 func init() {
@@ -39,4 +34,56 @@ func i422ToI420CGO(img *image.YCbCr) {
 	cLen := img.CStride * (h / 2)
 	img.Cb = img.Cb[:cLen]
 	img.Cr = img.Cr[:cLen]
+}
+
+func rgbToYCbCrCGO(y, cb, cr *uint8, r, g, b uint8) { // For testing
+	C.rgbToYCbCrCGO(
+		(*C.uchar)(y), (*C.uchar)(cb), (*C.uchar)(cr),
+		C.uchar(r), C.uchar(g), C.uchar(b),
+	)
+}
+
+func repeatRGBToYCbCrCGO(n int, y, cb, cr *uint8, r, g, b uint8) { // For testing
+	C.repeatRGBToYCbCrCGO(
+		C.int(n),
+		(*C.uchar)(y), (*C.uchar)(cb), (*C.uchar)(cr),
+		C.uchar(r), C.uchar(g), C.uchar(b),
+	)
+}
+
+func yCbCrToRGBCGO(r, g, b *uint8, y, cb, cr uint8) { // For testing
+	C.yCbCrToRGBCGO(
+		(*C.uchar)(r), (*C.uchar)(g), (*C.uchar)(b),
+		C.uchar(y), C.uchar(cb), C.uchar(cr),
+	)
+}
+
+func repeatYCbCrToRGBCGO(n int, r, g, b *uint8, y, cb, cr uint8) { // For testing
+	C.repeatYCbCrToRGBCGO(
+		C.int(n),
+		(*C.uchar)(r), (*C.uchar)(g), (*C.uchar)(b),
+		C.uchar(y), C.uchar(cb), C.uchar(cr),
+	)
+}
+
+func i444ToRGBACGO(dst *image.RGBA, src *image.YCbCr) {
+	C.i444ToRGBACGO(
+		(*C.uchar)(&dst.Pix[0]),
+		(*C.uchar)(&src.Y[0]),
+		(*C.uchar)(&src.Cb[0]),
+		(*C.uchar)(&src.Cr[0]),
+		C.int(src.Rect.Dx()),
+		C.int(src.Rect.Dy()),
+	)
+}
+
+func rgbaToI444(dst *image.YCbCr, src *image.RGBA) {
+	C.rgbaToI444(
+		(*C.uchar)(&dst.Y[0]),
+		(*C.uchar)(&dst.Cb[0]),
+		(*C.uchar)(&dst.Cr[0]),
+		(*C.uchar)(&src.Pix[0]),
+		C.int(src.Rect.Dx()),
+		C.int(src.Rect.Dy()),
+	)
 }

--- a/pkg/io/video/convert_cgo.go
+++ b/pkg/io/video/convert_cgo.go
@@ -1,0 +1,42 @@
+// +build cgo
+
+package video
+
+import (
+	"image"
+)
+
+// void i444ToI420CGO(
+//     unsigned char* cb, unsigned char* cr,
+//     const int stride, const int h);
+// void i422ToI420CGO(
+//     unsigned char* cb, unsigned char* cr,
+//     const int stride, const int h);
+import "C"
+
+func init() {
+	hasCGOConvert = true
+}
+
+func i444ToI420CGO(img *image.YCbCr) {
+	h := img.Rect.Dy()
+	C.i444ToI420CGO(
+		(*C.uchar)(&img.Cb[0]), (*C.uchar)(&img.Cr[0]),
+		C.int(img.CStride), C.int(h),
+	)
+	img.CStride = img.CStride / 2
+	cLen := img.CStride * (h / 2)
+	img.Cb = img.Cb[:cLen]
+	img.Cr = img.Cr[:cLen]
+}
+
+func i422ToI420CGO(img *image.YCbCr) {
+	h := img.Rect.Dy()
+	C.i422ToI420CGO(
+		(*C.uchar)(&img.Cb[0]), (*C.uchar)(&img.Cr[0]),
+		C.int(img.CStride), C.int(h),
+	)
+	cLen := img.CStride * (h / 2)
+	img.Cb = img.Cb[:cLen]
+	img.Cr = img.Cr[:cLen]
+}

--- a/pkg/io/video/convert_cgo.h
+++ b/pkg/io/video/convert_cgo.h
@@ -1,0 +1,57 @@
+void i444ToI420CGO(
+    unsigned char* cb,
+    unsigned char* cr,
+    const int stride, const int h);
+
+void i422ToI420CGO(
+    unsigned char* cb,
+    unsigned char* cr,
+    const int stride, const int h);
+
+void rgbToYCbCrCGO(
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char r,
+    const unsigned char g,
+    const unsigned char b);  // for testing
+
+void repeatRGBToYCbCrCGO(
+    const int n,
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char r,
+    const unsigned char g,
+    const unsigned char b);  // for testing
+
+void yCbCrToRGBCGO(
+    unsigned char* r,
+    unsigned char* g,
+    unsigned char* b,
+    const unsigned char y,
+    const unsigned char cb,
+    const unsigned char cr);  // for testing
+
+void repeatYCbCrToRGBCGO(
+    const int n,
+    unsigned char* r,
+    unsigned char* g,
+    unsigned char* b,
+    const unsigned char y,
+    const unsigned char cb,
+    const unsigned char cr);  // for testing
+
+void i444ToRGBACGO(
+    unsigned char* rgb,
+    const unsigned char* y,
+    const unsigned char* cb,
+    const unsigned char* cr,
+    const int stride, const int h);
+
+void rgbaToI444(
+    unsigned char* y,
+    unsigned char* cb,
+    unsigned char* cr,
+    const unsigned char* rgb,
+    const int stride, const int h);

--- a/pkg/io/video/convert_cgo_test.go
+++ b/pkg/io/video/convert_cgo_test.go
@@ -1,0 +1,84 @@
+// +build cgo
+
+package video
+
+import (
+	"image/color"
+	"testing"
+)
+
+func diffUint8(a, b uint8) uint8 {
+	d := int(a) - int(b)
+	if d < 0 {
+		d = -d
+	}
+	return uint8(d)
+}
+
+func TestRGBToYCbCr(t *testing.T) {
+	for r := 0; r < 0x100; r += 8 {
+		for g := 0; g < 0x100; g += 8 {
+			for b := 0; b < 0x100; b += 8 {
+				var y, cb, cr uint8
+				rgbToYCbCrCGO(&y, &cb, &cr, uint8(r), uint8(g), uint8(b))
+				y2, cb2, cr2 := color.RGBToYCbCr(uint8(r), uint8(g), uint8(b))
+				if diffUint8(y, y2) > 2 || diffUint8(cb, cb2) > 2 || diffUint8(cr, cr2) > 2 {
+					t.Fatalf(
+						"rgbToYCbCrCGO differs from color.RGBToYCbCr: in(%d, %d, %d), "+
+							"expected(%d, %d, %d), got(%d, %d, %d)",
+						r, g, b,
+						y2, cb2, cr2,
+						y, cb, cr,
+					)
+				}
+			}
+		}
+	}
+}
+
+func TestYCbCrToRGB(t *testing.T) {
+	for y := 0; y < 0x100; y += 8 {
+		for cb := 0; cb < 0x100; cb += 8 {
+			for cr := 0; cr < 0x100; cr += 8 {
+				var r, g, b uint8
+				yCbCrToRGBCGO(&r, &g, &b, uint8(y), uint8(cb), uint8(cr))
+				r2, g2, b2 := color.YCbCrToRGB(uint8(y), uint8(cb), uint8(cr))
+				if diffUint8(r, r2) > 2 || diffUint8(g, g2) > 2 || diffUint8(b, b2) > 2 {
+					t.Fatalf(
+						"yCbCrToRGBCGO differs from color.YCbCrToRGB: in(%d, %d, %d), "+
+							"expected(%d, %d, %d), got(%d, %d, %d)",
+						y, cb, cr,
+						r2, g2, b2,
+						r, g, b,
+					)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkRGBToYCbCr(b *testing.B) {
+	b.Run("Go", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _, _ = color.RGBToYCbCr(200, 100, 10)
+		}
+	})
+	b.Run("CGO", func(b *testing.B) {
+		var y, cb, cr uint8
+		// Loop in C code To ignore CGO call overhead
+		repeatRGBToYCbCrCGO(b.N, &y, &cb, &cr, 200, 100, 10)
+	})
+}
+
+func BenchmarkYCbCrToRGB(b *testing.B) {
+	b.Run("Go", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _, _ = color.YCbCrToRGB(200, 100, 10)
+		}
+	})
+	b.Run("CGO", func(b *testing.B) {
+		var rr, gg, bb uint8
+		// Loop in C code To ignore CGO call overhead
+		repeatYCbCrToRGBCGO(b.N, &rr, &gg, &bb, 200, 100, 10)
+	})
+}

--- a/pkg/io/video/convert_test.go
+++ b/pkg/io/video/convert_test.go
@@ -152,3 +152,12 @@ func BenchmarkToI420(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkToI420CGO(b *testing.B) {
+	if !hasCGOConvert {
+		b.SkipNow()
+	}
+	hasCGOConvert = false
+	b.Run("NoCGO", BenchmarkToI420)
+	hasCGOConvert = true
+}


### PR DESCRIPTION
```
BenchmarkToI420/480p/I444-4         	   17209	    238,403 ns/op
BenchmarkToI420/480p/I422-4         	   24540	    148,271 ns/op
BenchmarkToI420/1080p/I444-4        	    2365	  1,397,549 ns/op
BenchmarkToI420/1080p/I422-4        	    4168	    816,333 ns/op
BenchmarkToI420CGO/NoCGO/480p/I444-4             5720	    570,723 ns/op
BenchmarkToI420CGO/NoCGO/480p/I422-4             8224	    432,129 ns/op
BenchmarkToI420CGO/NoCGO/1080p/I444-4             997	  3,480,059 ns/op
BenchmarkToI420CGO/NoCGO/1080p/I422-4            1335	  2,602,584 ns/op
```
with `CGO_CFLAGS=-march=native -O3`
```
BenchmarkToI420/480p/I444-4         	   47775	     73,395 ns/op
BenchmarkToI420/480p/I422-4         	  109963	     32,822 ns/op
BenchmarkToI420/1080p/I444-4        	    8026	    484,568 ns/op
BenchmarkToI420/1080p/I422-4        	   22366	    157,334 ns/op
```
