### PR TITLE
Add support for non-discrete constraints

### DIFF
--- a/mediadevices.go
+++ b/mediadevices.go
@@ -196,15 +196,8 @@ func selectBestDriver(filter driver.FilterFn, constraints MediaTrackConstraints)
 		return nil, MediaTrackConstraints{}, errNotFound
 	}
 
-	// Reset Codec because bestProp only contains either audio.Prop or video.Prop
-	bestProp.Codec = constraints.Codec
-	bestConstraint := MediaTrackConstraints{
-		Media:          bestProp,
-		Enabled:        true,
-		AudioTransform: constraints.AudioTransform,
-		VideoTransform: constraints.VideoTransform,
-	}
-	return bestDriver, bestConstraint, nil
+	constraints.Merge(bestProp)
+	return bestDriver, constraints, nil
 }
 
 func (m *mediaDevices) selectAudio(constraints MediaTrackConstraints) (Tracker, error) {

--- a/pkg/prop/prop_test.go
+++ b/pkg/prop/prop_test.go
@@ -1,0 +1,75 @@
+package prop
+
+import (
+	"testing"
+)
+
+func TestMergeWithZero(t *testing.T) {
+	a := Media{
+		Video: Video{
+			Width: 30,
+		},
+	}
+
+	b := Media{
+		Video: Video{
+			Height: 100,
+		},
+	}
+
+	a.Merge(b)
+
+	if a.Width == 0 {
+		t.Error("expected a.Width to be 30, but got 0")
+	}
+
+	if a.Height == 0 {
+		t.Error("expected a.Height to be 100, but got 0")
+	}
+}
+
+func TestMergeWithSameField(t *testing.T) {
+	a := Media{
+		Video: Video{
+			Width: 30,
+		},
+	}
+
+	b := Media{
+		Video: Video{
+			Width: 100,
+		},
+	}
+
+	a.Merge(b)
+
+	if a.Width != 100 {
+		t.Error("expected a.Width to be 100, but got 0")
+	}
+}
+
+func TestMergeNested(t *testing.T) {
+	type constraints struct {
+		Media
+	}
+
+	a := constraints{
+		Media{
+			Video: Video{
+				Width: 30,
+			},
+		},
+	}
+
+	b := Media{
+		Video: Video{
+			Width: 100,
+		},
+	}
+
+	a.Merge(b)
+
+	if a.Width != 100 {
+		t.Error("expected a.Width to be 100, but got 0")
+	}
+}


### PR DESCRIPTION
This PR contains an alternative approach to https://github.com/pion/mediadevices/pull/71.

Resolves https://github.com/pion/mediadevices/issues/61

* Add a Merge method in prop
* Replace a manual merge in mediadevices in best property selection with the new Merge method