### PR TITLE
Fix AudioRecord automatic close when failed

### DIFF
--- a/pkg/driver/wrapper.go
+++ b/pkg/driver/wrapper.go
@@ -90,5 +90,8 @@ func (w *adapterWrapper) AudioRecord(p prop.Media) (r audio.Reader, err error) {
 		r, err = w.AudioRecorder.AudioRecord(p)
 		return err
 	})
+	if err != nil {
+		_ = w.Close()
+	}
 	return
 }


### PR DESCRIPTION
In https://github.com/pion/mediadevices/pull/75, we forgot to add the same automatic close for `AudioRecord`. I also added some unit tests to check this.