### PR TITLE
Add default package file for drivers

### DIFF
--- a/pkg/driver/camera/camera.go
+++ b/pkg/driver/camera/camera.go
@@ -1,0 +1,1 @@
+package camera

--- a/pkg/driver/microphone/microphone.go
+++ b/pkg/driver/microphone/microphone.go
@@ -1,0 +1,1 @@
+package microphone

--- a/pkg/driver/screen/screen.go
+++ b/pkg/driver/screen/screen.go
@@ -1,0 +1,1 @@
+package screen


### PR DESCRIPTION
Hi, maintainers! 

I was building the library on macOS but the following error caused.

```
build github.com/pion/mediadevices/pkg/driver/camera: cannot load github.com/pion/mediadevices/pkg/driver/camera: no Go source files
```

So I'd like to place the empty package files to make it buildable on any platform, thank you!