### PR TITLE
Fix CGO error handling of openh264 codec

### DIFF
--- a/pkg/codec/openh264/bridge.cpp
+++ b/pkg/codec/openh264/bridge.cpp
@@ -1,24 +1,23 @@
 #include "bridge.hpp"
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 
-Encoder *enc_new(const EncoderOptions opts) {
+Encoder *enc_new(const EncoderOptions opts, int *eresult) {
   int rv;
   ISVCEncoder *engine;
   SEncParamExt params;
 
   rv = WelsCreateSVCEncoder(&engine);
   if (rv != 0) {
-    errno = rv;
+    *eresult = rv;
     return NULL;
   }
 
   rv = engine->GetDefaultParams(&params);
   if (rv != 0) {
-    errno = rv;
+    *eresult = rv;
     return NULL;
   }
 
@@ -48,7 +47,7 @@ Encoder *enc_new(const EncoderOptions opts) {
 
   rv = engine->InitializeExt(&params);
   if (rv != 0) {
-    errno = rv;
+    *eresult = rv;
     return NULL;
   }
 
@@ -60,10 +59,10 @@ Encoder *enc_new(const EncoderOptions opts) {
   return encoder;
 }
 
-void enc_free(Encoder *e) {
+void enc_free(Encoder *e, int *eresult) {
   int rv = e->engine->Uninitialize();
   if (rv != 0) {
-    errno = rv;
+    *eresult = rv;
     return;
   }
 
@@ -75,7 +74,7 @@ void enc_free(Encoder *e) {
 
 // There's a good reference from ffmpeg in using the encode_frame
 // Reference: https://ffmpeg.org/doxygen/2.6/libopenh264enc_8c_source.html
-Slice enc_encode(Encoder *e, Frame f) {
+Slice enc_encode(Encoder *e, Frame f, int *eresult) {
   int rv;
   SSourcePicture pic = {0};
   SFrameBSInfo info = {0};
@@ -93,7 +92,7 @@ Slice enc_encode(Encoder *e, Frame f) {
 
   rv = e->engine->EncodeFrame(&pic, &info);
   if (rv != 0) {
-    errno = rv;
+    *eresult = rv;
     return payload;
   }
 

--- a/pkg/codec/openh264/bridge.hpp
+++ b/pkg/codec/openh264/bridge.hpp
@@ -29,9 +29,9 @@ typedef struct Encoder {
   int buff_size;
 } Encoder;
 
-Encoder *enc_new(const EncoderOptions params);
-void enc_free(Encoder *e);
-Slice enc_encode(Encoder *e, Frame f);
+Encoder *enc_new(const EncoderOptions params, int *eresult);
+void enc_free(Encoder *e, int *eresult);
+Slice enc_encode(Encoder *e, Frame f, int *eresult);
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/codec/openh264/error.go
+++ b/pkg/codec/openh264/error.go
@@ -1,0 +1,45 @@
+package openh264
+
+import (
+	"fmt"
+)
+
+import "C"
+
+type eResult int
+
+const (
+	retSuccess      eResult = 0
+	retFailed       eResult = -1
+	retInvalidParam eResult = -2
+	retOutOfMemory  eResult = -3
+	retNotSupported eResult = -4
+	retUnexpected   eResult = -5
+	retNeedReinit   eResult = -6
+)
+
+func (e eResult) Error() string {
+	switch e {
+	case retFailed:
+		return "failed"
+	case retInvalidParam:
+		return "invalid param"
+	case retOutOfMemory:
+		return "out of memory"
+	case retNotSupported:
+		return "not supported"
+	case retUnexpected:
+		return "unexpected"
+	case retNeedReinit:
+		return "need reinit"
+	default:
+		return fmt.Sprintf("unknown error (%d)", e)
+	}
+}
+
+func errResult(e C.int) error {
+	if e == 0 {
+		return nil
+	}
+	return eResult(e)
+}


### PR DESCRIPTION
Errno based error handling is not goroutine safe on Darwin.
Receive error number as int pointer and wrap by error interface.