### PR TITLE
Add box sampling scaler

### DIFF
--- a/pkg/io/video/scaler_cgo.c
+++ b/pkg/io/video/scaler_cgo.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
+#include <string.h>
 #include "_cgo_export.h"
 
 void fastNearestNeighbor(
-    unsigned char* dst, unsigned const char* src,
+    uint8_t* dst, const uint8_t* src,
     const int ch,
     const int dw, const int dh, const int dstride,
     const int sw, const int sh, const int sstride)
@@ -9,7 +11,7 @@ void fastNearestNeighbor(
   for (int dy = 0; dy < dh; dy++)
   {
     const int sy = dy * sh / dh;
-    const unsigned char* src2 = &src[sy * sstride];
+    const uint8_t* src2 = &src[sy * sstride];
 
     for (int dx = 0; dx < dw; dx++)
     {
@@ -17,5 +19,42 @@ void fastNearestNeighbor(
       for (int c = 0; c < ch; c++)
         *(dst++) = src2[sx + c];
     }
+  }
+}
+
+void fastBoxSampling(
+    uint8_t* dst, const uint8_t* src,
+    const int ch,
+    const int dw, const int dh, const int dstride,
+    const int sw, const int sh, const int sstride,
+    uint32_t* tmp)
+{
+  memset(tmp, 0, dw * dh * ch);
+
+  for (int sy = 0; sy < sh; sy++)
+  {
+    const uint8_t* src2 = &src[sy * sstride];
+    int tx = 0;
+    const int ty = sy * dh / sh;
+    uint32_t* tmp2 = &tmp[ty * dstride];
+    for (int sx = 0; sx < sw * ch; sx += ch)
+    {
+      if (tx * sw < sx * dw)
+        tx += ch;
+
+      for (int c = 0; c < ch; c++)
+      {
+        tmp2[tx + c] += 0x10000 | src2[sx + c];
+      }
+    }
+  }
+
+  for (int i = 0; i < dw * dh * ch; i++)
+  {
+    const uint32_t tmp2 = tmp[i];
+    const uint16_t sum = tmp2 & 0xFFFF;
+    const uint16_t num = tmp2 >> 16;
+    if (num > 0)
+      dst[i] = sum / num;
   }
 }

--- a/pkg/io/video/scaler_cgo.go
+++ b/pkg/io/video/scaler_cgo.go
@@ -5,13 +5,21 @@ package video
 import (
 	"golang.org/x/image/draw"
 	"image"
+	"sync"
 )
 
+// #include <stdint.h>
 // void fastNearestNeighbor(
-//     unsigned char* dst, unsigned const char* src,
+//     uint8_t* dst, const uint8_t* src,
 //     const int ch,
 //     const int dw, const int dh, const int dstride,
 //     const int sw, const int sh, const int sstride);
+// void fastBoxSampling(
+//     uint8_t* dst, const uint8_t* src,
+//     const int ch,
+//     const int dw, const int dh, const int dstride,
+//     const int sw, const int sh, const int sstride,
+//     uint32_t* tmp);
 import "C"
 
 // List of scaling algorithms
@@ -19,7 +27,16 @@ var (
 	// ScalerFastNearestNeighbor is a CGO version of NearestNeighbor scaler.
 	// This is roughly 4-times faster than draw.NearestNeighbor.
 	ScalerFastNearestNeighbor = Scaler(&FastNearestNeighbor{})
+	// ScalerFastBoxSampling is a CGO implementation of BoxSampling scaler.
+	// This is heavyer than NearestNeighbor but keeps detail on down scaling.
+	ScalerFastBoxSampling = Scaler(&FastBoxSampling{})
 )
+
+var poolBoxSampleBuffer = sync.Pool{
+	New: func() interface{} {
+		return &([]uint32{})
+	},
+}
 
 var (
 	scalerTestAlgosCGO = map[string]Scaler{
@@ -27,6 +44,7 @@ var (
 	}
 	scalerBenchAlgosCGO = map[string]Scaler{
 		"FastNearestNeighbor": ScalerFastNearestNeighbor,
+		"FastBoxSampling":     ScalerFastBoxSampling,
 	}
 )
 
@@ -78,6 +96,75 @@ func (f *FastNearestNeighbor) Scale(dst draw.Image, dr image.Rectangle, src imag
 			1,
 			C.int(dr.Dx()), C.int(dr.Dy()), C.int(d.Stride),
 			C.int(sr.Dx()), C.int(sr.Dy()), C.int(s.Stride),
+		)
+
+	case (*rgbLikeYCbCr):
+		d := dst.(*rgbLikeYCbCr)
+		f.Scale(d.y, dr, s.y, sr, op, opts)
+		dr2 := image.Rect(0, 0, d.cb.Stride, len(d.cb.Pix)/d.cb.Stride)
+		sr2 := image.Rect(0, 0, s.cb.Stride, len(s.cb.Pix)/s.cb.Stride)
+		f.Scale(d.cb, dr2, s.cb, sr2, op, opts)
+		f.Scale(d.cr, dr2, s.cr, sr2, op, opts)
+
+	default:
+		panic("unimplemented")
+	}
+}
+
+// FastBoxSampling is a CGO version of Box sampling scaler.
+type FastBoxSampling struct {
+}
+
+// Scale implements the draw.Scaler interface.
+func (f *FastBoxSampling) Scale(dst draw.Image, dr image.Rectangle, src image.Image, sr image.Rectangle, op draw.Op, opts *draw.Options) {
+	if sr.Dx() < dr.Dx() && sr.Dy() < dr.Dy() {
+		// Box upsampling is equivalent of NearestNeighbor
+		(&FastNearestNeighbor{}).Scale(dst, dr, src, sr, op, opts)
+		return
+	}
+	tmp := poolBoxSampleBuffer.Get().(*[]uint32)
+	defer poolBoxSampleBuffer.Put(tmp)
+
+	switch s := src.(type) {
+	case (*image.RGBA):
+		d := dst.(*image.RGBA)
+		l := d.Stride * d.Rect.Dy()
+		if len(d.Pix) < l {
+			if cap(d.Pix) < l {
+				d.Pix = make([]uint8, l)
+			}
+			d.Pix = d.Pix[:l]
+		}
+		if len(*tmp) < l {
+			*tmp = make([]uint32, l)
+		}
+		C.fastBoxSampling(
+			(*C.uchar)(&d.Pix[dr.Min.X+d.Stride*dr.Min.Y]),
+			(*C.uchar)(&s.Pix[sr.Min.X+s.Stride*sr.Min.Y]),
+			4,
+			C.int(dr.Dx()), C.int(dr.Dy()), C.int(d.Stride),
+			C.int(sr.Dx()), C.int(sr.Dy()), C.int(s.Stride),
+			(*C.uint32_t)(&(*tmp)[0]),
+		)
+	case (*image.Gray):
+		d := dst.(*image.Gray)
+		l := d.Stride * d.Rect.Dy()
+		if len(d.Pix) < l {
+			if cap(d.Pix) < l {
+				d.Pix = make([]uint8, l)
+			}
+			d.Pix = d.Pix[:l]
+		}
+		if len(*tmp) < l {
+			*tmp = make([]uint32, l)
+		}
+		C.fastBoxSampling(
+			(*C.uchar)(&d.Pix[dr.Min.X+d.Stride*dr.Min.Y]),
+			(*C.uchar)(&s.Pix[sr.Min.X+s.Stride*sr.Min.Y]),
+			1,
+			C.int(dr.Dx()), C.int(dr.Dy()), C.int(d.Stride),
+			C.int(sr.Dx()), C.int(sr.Dy()), C.int(s.Stride),
+			(*C.uint32_t)(&(*tmp)[0]),
 		)
 
 	case (*rgbLikeYCbCr):


### PR DESCRIPTION
NearestNeighbor | BoxSampling
--- | ---
![Screenshot from 2020-02-26 00-15-54](https://user-images.githubusercontent.com/8390204/75261177-fd05a680-582d-11ea-8c05-9b91dc0846be.png) | ![Screenshot from 2020-02-26 00-17-07](https://user-images.githubusercontent.com/8390204/75261179-ff680080-582d-11ea-8ff8-7c4af6f234c2.png)

```
$ CGO_CFLAGS="-march=native -O3" go test . -bench BenchmarkScale/Fast -benchmem -benchtime 3s
goos: linux
goarch: amd64
pkg: github.com/pion/mediadevices/pkg/io/video
BenchmarkScale/FastNearestNeighbor/480p/RGBA-4         	    1419	   2156141 ns/op	     716 B/op	       1 allocs/op
BenchmarkScale/FastNearestNeighbor/480p/I444-4         	     441	   7967492 ns/op	    3566 B/op	       1 allocs/op
BenchmarkScale/FastNearestNeighbor/1080p/RGBA-4        	    1574	   2248581 ns/op	     652 B/op	       1 allocs/op
BenchmarkScale/FastNearestNeighbor/1080p/I444-4        	     426	   8358253 ns/op	    3687 B/op	       1 allocs/op
BenchmarkScale/FastBoxSampling/480p/RGBA-4             	     559	   6228782 ns/op	    8317 B/op	       1 allocs/op
BenchmarkScale/FastBoxSampling/480p/I444-4             	     416	   9021733 ns/op	    6001 B/op	       1 allocs/op
BenchmarkScale/FastBoxSampling/1080p/RGBA-4            	     144	  24268477 ns/op	   32102 B/op	       1 allocs/op
BenchmarkScale/FastBoxSampling/1080p/I444-4            	     100	  32458101 ns/op	   24561 B/op	       1 allocs/op
PASS
ok  	github.com/pion/mediadevices/pkg/io/video	37.338s
```