### PR TITLE
Add CGO version of decodeYUY2

### DIFF
--- a/pkg/frame/yuv.c
+++ b/pkg/frame/yuv.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+void decodeYUY2CGO(
+    uint8_t* y,
+    uint8_t* cb,
+    uint8_t* cr,
+    uint8_t* yuy2,
+    int width, int height)
+{
+  const int l = width * height * 2;
+  int i, fast = 0, slow = 0;
+  for (i = 0; i < l; i += 4)
+  {
+    y[fast] = yuy2[i];
+    cb[slow] = yuy2[i + 1];
+    y[fast + 1] = yuy2[i + 2];
+    cr[slow] = yuy2[i + 3];
+    fast += 2;
+    ++slow;
+  }
+}

--- a/pkg/frame/yuv.go
+++ b/pkg/frame/yuv.go
@@ -49,38 +49,3 @@ func decodeNV21(frame []byte, width, height int) (image.Image, error) {
 		Rect:           image.Rect(0, 0, width, height),
 	}, nil
 }
-
-func decodeYUY2(frame []byte, width, height int) (image.Image, error) {
-	yi := width * height
-	ci := yi / 2
-	fi := yi + 2*ci
-
-	if len(frame) != fi {
-		return nil, fmt.Errorf("frame length (%d) less than expected (%d)", len(frame), fi)
-	}
-
-	y := make([]byte, yi)
-	cb := make([]byte, ci)
-	cr := make([]byte, ci)
-
-	fast := 0
-	slow := 0
-	for i := 0; i < fi; i += 4 {
-		y[fast] = frame[i]
-		cb[slow] = frame[i+1]
-		y[fast+1] = frame[i+2]
-		cr[slow] = frame[i+3]
-		fast += 2
-		slow++
-	}
-
-	return &image.YCbCr{
-		Y:              y,
-		YStride:        width,
-		Cb:             cb,
-		Cr:             cr,
-		CStride:        width / 2,
-		SubsampleRatio: image.YCbCrSubsampleRatio422,
-		Rect:           image.Rect(0, 0, width, height),
-	}, nil
-}

--- a/pkg/frame/yuv_cgo.go
+++ b/pkg/frame/yuv_cgo.go
@@ -1,0 +1,44 @@
+// +build cgo
+
+package frame
+
+import (
+	"fmt"
+	"image"
+)
+
+// #include <stdint.h>
+// void decodeYUY2CGO(uint8_t* y, uint8_t* cb, uint8_t* cr, uint8_t* yuy2, int width, int height);
+import "C"
+
+func decodeYUY2(frame []byte, width, height int) (image.Image, error) {
+	yi := width * height
+	ci := yi / 2
+	fi := yi + 2*ci
+
+	if len(frame) != fi {
+		return nil, fmt.Errorf("frame length (%d) less than expected (%d)", len(frame), fi)
+	}
+
+	y := make([]byte, yi)
+	cb := make([]byte, ci)
+	cr := make([]byte, ci)
+
+	C.decodeYUY2CGO(
+		(*C.uchar)(&y[0]),
+		(*C.uchar)(&cb[0]),
+		(*C.uchar)(&cr[0]),
+		(*C.uchar)(&frame[0]),
+		C.int(width), C.int(height),
+	)
+
+	return &image.YCbCr{
+		Y:              y,
+		YStride:        width,
+		Cb:             cb,
+		Cr:             cr,
+		CStride:        width / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio422,
+		Rect:           image.Rect(0, 0, width, height),
+	}, nil
+}

--- a/pkg/frame/yuv_nocgo.go
+++ b/pkg/frame/yuv_nocgo.go
@@ -1,0 +1,43 @@
+// +build !cgo
+
+package frame
+
+import (
+	"fmt"
+	"image"
+)
+
+func decodeYUY2(frame []byte, width, height int) (image.Image, error) {
+	yi := width * height
+	ci := yi / 2
+	fi := yi + 2*ci
+
+	if len(frame) != fi {
+		return nil, fmt.Errorf("frame length (%d) less than expected (%d)", len(frame), fi)
+	}
+
+	y := make([]byte, yi)
+	cb := make([]byte, ci)
+	cr := make([]byte, ci)
+
+	fast := 0
+	slow := 0
+	for i := 0; i < fi; i += 4 {
+		y[fast] = frame[i]
+		cb[slow] = frame[i+1]
+		y[fast+1] = frame[i+2]
+		cr[slow] = frame[i+3]
+		fast += 2
+		slow++
+	}
+
+	return &image.YCbCr{
+		Y:              y,
+		YStride:        width,
+		Cb:             cb,
+		Cr:             cr,
+		CStride:        width / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio422,
+		Rect:           image.Rect(0, 0, width, height),
+	}, nil
+}

--- a/pkg/frame/yuv_test.go
+++ b/pkg/frame/yuv_test.go
@@ -1,0 +1,58 @@
+package frame
+
+import (
+	"fmt"
+	"image"
+	"reflect"
+	"testing"
+)
+
+func TestDecodeYUY2(t *testing.T) {
+	const (
+		width  = 2
+		height = 2
+	)
+	input := []byte{
+		// Y    Cb     Y    Cr
+		0x01, 0x82, 0x03, 0x84,
+		0x05, 0x86, 0x07, 0x88,
+	}
+	expected := &image.YCbCr{
+		Y:              []byte{0x01, 0x03, 0x05, 0x07},
+		YStride:        width,
+		Cb:             []byte{0x82, 0x86},
+		Cr:             []byte{0x84, 0x88},
+		CStride:        width / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio422,
+		Rect:           image.Rect(0, 0, width, height),
+	}
+
+	img, err := decodeYUY2(input, width, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, img) {
+		t.Errorf("Wrong decode result,\nexpected:\n%+v\ngot:\n%+v", expected, img)
+	}
+}
+
+func BenchmarkDecodeYUY2(b *testing.B) {
+	sizes := []struct {
+		width, height int
+	}{
+		{640, 480},
+		{1920, 1080},
+	}
+	for _, sz := range sizes {
+		sz := sz
+		b.Run(fmt.Sprintf("%dx%d", sz.width, sz.height), func(b *testing.B) {
+			input := make([]byte, sz.width*sz.height*2)
+			for i := 0; i < b.N; i++ {
+				_, err := decodeYUY2(input, sz.width, sz.height)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go
```
$ CGO_ENABLED=0 go test . -bench . -benchtime 5s
BenchmarkDecodeYUY2/640x480-4               7041       889,028 ns/op    
BenchmarkDecodeYUY2/1920x1080-4              883     6,616,224 ns/op   
```
CGO
```
$ go test . -bench . -benchtime 5s
BenchmarkDecodeYUY2/640x480-4              12721       502,289 ns/op    
BenchmarkDecodeYUY2/1920x1080-4             1694     3,451,253 ns/op   
```

CGO with gcc optimization
```
$ CGO_CFLAGS="-march=native -O3" go test . -bench . -benchtime 5s
BenchmarkDecodeYUY2/640x480-4              39645       164,450 ns/op    
BenchmarkDecodeYUY2/1920x1080-4             4682     1,195,134 ns/op   
```

### Reference issue
Fixes #103 