### PR TITLE
Support codec specific parameters

### DIFF
--- a/examples/codecparam/README.md
+++ b/examples/codecparam/README.md
@@ -1,0 +1,29 @@
+## Instructions
+
+### Download example
+
+```
+go get github.com/pion/mediadevices/examples/codecparam
+```
+
+### Open example page
+
+[jsfiddle.net](https://jsfiddle.net/z7ms3u5r/) you should see two text-areas and a 'Start Session' button
+
+### Run simple with your browsers SessionDescription as stdin
+
+In the jsfiddle the top textarea is your browser, copy that and:
+
+#### Linux
+
+Run `echo $BROWSER_SDP | simple`
+
+### Input simple's SessionDescription into your browser
+
+Copy the text that `simple` just emitted and copy into second text area
+
+### Hit 'Start Session' in jsfiddle, enjoy your video!
+
+A video should start playing in your browser above the input boxes, and will continue playing until you close the application.
+
+Congrats, you have used pion-WebRTC! Now start building something cool

--- a/examples/codecparam/main.go
+++ b/examples/codecparam/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pion/mediadevices"
+	"github.com/pion/mediadevices/examples/internal/signal"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/webrtc/v2"
+
+	_ "github.com/pion/mediadevices/pkg/codec/opus" // This is required to register opus audio encoder
+	"github.com/pion/mediadevices/pkg/codec/vpx"    // This is required to register VP8/VP9 video encoder
+
+	// Note: If you don't have a camera or microphone or your adapters are not supported,
+	//       you can always swap your adapters with our dummy adapters below.
+	// _ "github.com/pion/mediadevices/pkg/driver/videotest"
+	// _ "github.com/pion/mediadevices/pkg/driver/audiotest"
+	_ "github.com/pion/mediadevices/pkg/driver/camera"     // This is required to register camera adapter
+	_ "github.com/pion/mediadevices/pkg/driver/microphone" // This is required to register microphone adapter
+)
+
+func main() {
+	config := webrtc.Configuration{
+		ICEServers: []webrtc.ICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	}
+
+	// Wait for the offer to be pasted
+	offer := webrtc.SessionDescription{}
+	signal.Decode(signal.MustReadStdin(), &offer)
+
+	// Create a new RTCPeerConnection
+	mediaEngine := webrtc.MediaEngine{}
+	if err := mediaEngine.PopulateFromSDP(offer); err != nil {
+		panic(err)
+	}
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(mediaEngine))
+	peerConnection, err := api.NewPeerConnection(config)
+	if err != nil {
+		panic(err)
+	}
+
+	// Set the handler for ICE connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
+		fmt.Printf("Connection State has changed %s \n", connectionState.String())
+	})
+
+	md := mediadevices.NewMediaDevices(peerConnection)
+
+	s, err := md.GetUserMedia(mediadevices.MediaStreamConstraints{
+		Audio: func(c *mediadevices.MediaTrackConstraints) {
+			c.CodecName = webrtc.Opus
+			c.Enabled = true
+			c.BitRate = 32000 // 32kbps
+		},
+		Video: func(c *mediadevices.MediaTrackConstraints) {
+			c.CodecName = webrtc.VP8
+			c.FrameFormat = frame.FormatYUY2
+			c.Enabled = true
+			c.Width = 640
+			c.Height = 480
+			c.BitRate = 400000 // 400kbps
+
+			// Load default parameters.
+			cp, err := vpx.NewVP8Param()
+			if err != nil {
+				panic(err)
+			}
+			fmt.Printf("default codec parameters: %+v\n", cp)
+
+			// Set parameters to avoid bitrate overshoot as possible.
+			cp.RateControlEndUsage = vpx.RateControlCBR
+			cp.RateControlOvershootPercent = 1
+			cp.RateControlUndershootPercent = 95
+			c.CodecParams = cp
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tracker := range s.GetTracks() {
+		t := tracker.Track()
+		tracker.OnEnded(func(err error) {
+			fmt.Printf("Track (ID: %s, Label: %s) ended with error: %v\n",
+				t.ID(), t.Label(), err)
+		})
+		_, err = peerConnection.AddTransceiverFromTrack(t,
+			webrtc.RtpTransceiverInit{
+				Direction: webrtc.RTPTransceiverDirectionSendonly,
+			},
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Set the remote SessionDescription
+	err = peerConnection.SetRemoteDescription(offer)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create an answer
+	answer, err := peerConnection.CreateAnswer(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output the answer in base64 so we can paste it in browser
+	fmt.Println(signal.Encode(answer))
+	select {}
+}

--- a/pkg/codec/openh264/openh264.go
+++ b/pkg/codec/openh264/openh264.go
@@ -9,6 +9,7 @@ package openh264
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"io"
@@ -41,6 +42,10 @@ func init() {
 func NewEncoder(r video.Reader, p prop.Media) (io.ReadCloser, error) {
 	if p.BitRate == 0 {
 		p.BitRate = 100000
+	}
+
+	if p.CodecParams != nil {
+		return nil, errors.New("unsupported CodecParams type")
 	}
 
 	var rv C.int

--- a/pkg/codec/opus/opus.go
+++ b/pkg/codec/opus/opus.go
@@ -1,6 +1,7 @@
 package opus
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -40,6 +41,10 @@ func NewEncoder(r audio.Reader, p prop.Media) (io.ReadCloser, error) {
 
 	if p.BitRate == 0 {
 		p.BitRate = 32000
+	}
+
+	if p.CodecParams != nil {
+		return nil, errors.New("unsupported CodecParams type")
 	}
 
 	// Select the nearest supported latency

--- a/pkg/codec/vpx/params.go
+++ b/pkg/codec/vpx/params.go
@@ -1,0 +1,21 @@
+package vpx
+
+// Params stores libvpx specific encoding parameters.
+// Value range is codec (VP8/VP9) specific.
+type Params struct {
+	RateControlEndUsage          RateControlMode
+	RateControlUndershootPercent uint
+	RateControlOvershootPercent  uint
+	RateControlMinQuantizer      uint
+	RateControlMaxQuantizer      uint
+}
+
+// RateControlMode represents rate control mode.
+type RateControlMode int
+
+// RateControlMode values.
+const (
+	RateControlVBR RateControlMode = iota
+	RateControlCBR
+	RateControlCQ
+)

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -119,11 +119,9 @@ type Codec struct {
 	// Target bitrate in bps.
 	BitRate int
 
-	// Quolity of the encoding [0-9].
-	// Larger value results higher quality and higher CPU usage.
-	// It depends on the selected codec.
-	Quality int
-
 	// Expected interval of the keyframes in frames.
 	KeyFrameInterval int
+
+	// Library specific parameter struct defined by each codec package
+	CodecParams interface{}
 }


### PR DESCRIPTION
I'd like to introduce it to vaapi codec (#102), which has a lot of low layer parameters and no API to get library default parameters like openh264 and vpx.

### Reference issue
Fixes #105 