### PR TITLE
Avoid double free

### DIFF
--- a/pkg/codec/x264/bridge.h
+++ b/pkg/codec/x264/bridge.h
@@ -20,7 +20,7 @@ typedef struct Encoder {
   x264_param_t param;
 } Encoder;
 
-Encoder *enc_new(x264_param_t param, char *preset, int* rc) {
+Encoder *enc_new(x264_param_t param, char *preset, int *rc) {
   Encoder *e = (Encoder *)malloc(sizeof(Encoder));
 
   if (x264_param_default_preset(&e->param, preset, "zerolatency") < 0) {
@@ -71,7 +71,7 @@ fail:
   return NULL;
 }
 
-Slice enc_encode(Encoder *e, uint8_t *y, uint8_t *cb, uint8_t *cr, int* rc) {
+Slice enc_encode(Encoder *e, uint8_t *y, uint8_t *cb, uint8_t *cr, int *rc) {
   x264_nal_t *nal;
   int i_nal;
 
@@ -91,7 +91,7 @@ Slice enc_encode(Encoder *e, uint8_t *y, uint8_t *cb, uint8_t *cr, int* rc) {
   return s;
 }
 
-void enc_close(Encoder *e, int* rc) {
+void enc_close(Encoder *e, int *rc) {
   x264_encoder_close(e->h);
   x264_picture_clean(&e->pic_in);
   free(e);

--- a/pkg/codec/x264/x264.go
+++ b/pkg/codec/x264/x264.go
@@ -153,6 +153,10 @@ func (e *encoder) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return nil
+	}
+
 	var rc C.int
 	C.enc_close(e.engine, &rc)
 	e.closed = true


### PR DESCRIPTION
#### Description
Somehow x264 encoder got closed more than once when `cleanTrackers` is called in `getUserMedia`, and double free occurred:

```
x264 [info]: using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
x264 [info]: profile Constrained Baseline, level 5.1
x264 [info]: frame I:1     Avg QP: 0.00  size:193627
x264 [info]: mb I  I16..4: 100.0%  0.0%  0.0%
x264 [info]: coded y,uvDC,uvAC intra: 100.0% 100.0% 100.0%
x264 [info]: i16 v,h,dc,p: 10% 17% 54% 19%
x264 [info]: i8c dc,h,v,p: 45% 31% 14% 11%
x264 [info]: kb/s:38725.40
munmap_chunk(): invalid pointer
SIGABRT: abort
PC=0x7f88ae9e53eb m=3 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: unknown pc 0x7f88ae9e53eb
stack: frame={sp:0x7f88abde1a40, fp:0x0} stack=[0x7f88ab5e2288,0x7f88abde1e88)
00007f88abde1940:  0000000000000000  0000000000000000 
00007f88abde1950:  00007f88af152190  00007f88af1524f0 
00007f88abde1960:  0000000000000000  00007f88a0002100 
00007f88abde1970:  00007f8800000001  00007f88aeeb6a4f 
00007f88abde1980:  00000000ffffffff  00007f88a0001c10 
00007f88abde1990:  00007f88aee4bb10  00007f88af106000 
00007f88abde19a0:  0000004000000018  00007f88aea37c8f 
00007f88abde19b0:  0000000000000000  00007f88aea3905b 
00007f88abde19c0:  149b6c51b98c0cc3  0000000000012230 
00007f88abde19d0:  00007f88a0000020  0000000000c380b8 
00007f88abde19e0:  00007f88a0001570  ffffffffffffffff 
00007f88abde19f0:  0000000000000114  0000000000000113 
00007f88abde1a00:  0000000000000200  00007f88af1347b7 
00007f88abde1a10:  0000000000000005  0000000000000000 
00007f88abde1a20:  0000000000020000  00007f88aee4bb10 
00007f88abde1a30:  00007f88abde1e10  00007f88af13ba9e 
00007f88abde1a40: <0000000000000000  0000000000000002 
00007f88abde1a50:  00007f88a001eb80  00007f88a0001ba0 
00007f88abde1a60:  00007f88a0001578  0000000000000001 
00007f88abde1a70:  0000000000000001  00007f88aeedbe1c 
00007f88abde1a80:  000000003f7b704d  0000000000000451 
00007f88abde1a90:  0000000000000000  0000ffff00001fb2 
00007f88abde1aa0:  00007f88abddf600  000000c00027d608 
00007f88abde1ab0:  000000c000280000  0000040000000000 
00007f88abde1ac0:  fffffffe7fffffff  ffffffffffffffff 
00007f88abde1ad0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1ae0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1af0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b00:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b10:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b20:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b30:  ffffffffffffffff  ffffffffffffffff 
runtime: unknown pc 0x7f88ae9e53eb
stack: frame={sp:0x7f88abde1a40, fp:0x0} stack=[0x7f88ab5e2288,0x7f88abde1e88)
00007f88abde1940:  0000000000000000  0000000000000000 
00007f88abde1950:  00007f88af152190  00007f88af1524f0 
00007f88abde1960:  0000000000000000  00007f88a0002100 
00007f88abde1970:  00007f8800000001  00007f88aeeb6a4f 
00007f88abde1980:  00000000ffffffff  00007f88a0001c10 
00007f88abde1990:  00007f88aee4bb10  00007f88af106000 
00007f88abde19a0:  0000004000000018  00007f88aea37c8f 
00007f88abde19b0:  0000000000000000  00007f88aea3905b 
00007f88abde19c0:  149b6c51b98c0cc3  0000000000012230 
00007f88abde19d0:  00007f88a0000020  0000000000c380b8 
00007f88abde19e0:  00007f88a0001570  ffffffffffffffff 
00007f88abde19f0:  0000000000000114  0000000000000113 
00007f88abde1a00:  0000000000000200  00007f88af1347b7 
00007f88abde1a10:  0000000000000005  0000000000000000 
00007f88abde1a20:  0000000000020000  00007f88aee4bb10 
00007f88abde1a30:  00007f88abde1e10  00007f88af13ba9e 
00007f88abde1a40: <0000000000000000  0000000000000002 
00007f88abde1a50:  00007f88a001eb80  00007f88a0001ba0 
00007f88abde1a60:  00007f88a0001578  0000000000000001 
00007f88abde1a70:  0000000000000001  00007f88aeedbe1c 
00007f88abde1a80:  000000003f7b704d  0000000000000451 
00007f88abde1a90:  0000000000000000  0000ffff00001fb2 
00007f88abde1aa0:  00007f88abddf600  000000c00027d608 
00007f88abde1ab0:  000000c000280000  0000040000000000 
00007f88abde1ac0:  fffffffe7fffffff  ffffffffffffffff 
00007f88abde1ad0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1ae0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1af0:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b00:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b10:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b20:  ffffffffffffffff  ffffffffffffffff 
00007f88abde1b30:  ffffffffffffffff  ffffffffffffffff 

goroutine 1 [syscall]:
runtime.cgocall(0x7fa550, 0xc0001ab9e8, 0x1)
        /usr/lib/go-1.13/src/runtime/cgocall.go:128 +0x5b fp=0xc0001ab9b8 sp=0xc0001ab980 pc=0x40649b
github.com/pion/mediadevices/pkg/codec/x264._Cfunc_enc_close(0x7f88a0001570, 0xc000229124)
        _cgo_gotypes.go:368 +0x41 fp=0xc0001ab9e8 sp=0xc0001ab9b8 pc=0x7e5bf1
github.com/pion/mediadevices/pkg/codec/x264.(*encoder).Close.func1(0xc000224100, 0xc000229124)
        /home/lukas/Documents/pion/mediadevices/pkg/codec/x264/x264.go:161 +0x68 fp=0xc0001aba28 sp=0xc0001ab9e8 pc=0x7e6dd8
github.com/pion/mediadevices/pkg/codec/x264.(*encoder).Close(0xc000224100, 0x0, 0x0)
        /home/lukas/Documents/pion/mediadevices/pkg/codec/x264/x264.go:161 +0x8e fp=0xc0001aba88 sp=0xc0001aba28 pc=0x7e69ee
github.com/pion/mediadevices.(*videoTrack).Stop(0xc0002261a0)
        /home/lukas/Documents/pion/mediadevices/track.go:182 +0x51 fp=0xc0001abab0 sp=0xc0001aba88 pc=0x77f7c1
github.com/pion/mediadevices.(*mediaDevices).GetUserMedia.func1()
        /home/lukas/Documents/pion/mediadevices/mediadevices.go:124 +0x60 fp=0xc0001abae0 sp=0xc0001abab0 pc=0x780090
github.com/pion/mediadevices.(*mediaDevices).GetUserMedia(0xc000200130, 0x927f10, 0x927f18, 0x0, 0x9a3340, 0xc000200130, 0x0)
        /home/lukas/Documents/pion/mediadevices/mediadevices.go:163 +0x1b5 fp=0xc0001abd90 sp=0xc0001abae0 pc=0x77c695
main.main()
        /home/lukas/Documents/pion/mediadevices/examples/simple/main.go:63 +0x2e0 fp=0xc0001abf60 sp=0xc0001abd90 pc=0x7f9a20
runtime.main()
        /usr/lib/go-1.13/src/runtime/proc.go:203 +0x21e fp=0xc0001abfe0 sp=0xc0001abf60 pc=0x4323ae
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001abfe8 sp=0xc0001abfe0 pc=0x45ce41

goroutine 2 [force gc (idle)]:
runtime.gopark(0x9284f8, 0xc7c620, 0x1411, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005efb0 sp=0xc00005ef90 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.forcegchelper()
        /usr/lib/go-1.13/src/runtime/proc.go:253 +0xb7 fp=0xc00005efe0 sp=0xc00005efb0 pc=0x432637
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005efe8 sp=0xc00005efe0 pc=0x45ce41
created by runtime.init.5
        /usr/lib/go-1.13/src/runtime/proc.go:242 +0x35

goroutine 3 [GC sweep wait]:
runtime.gopark(0x9284f8, 0xc7c760, 0x140c, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005f7a8 sp=0xc00005f788 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.bgsweep(0xc000084000)
        /usr/lib/go-1.13/src/runtime/mgcsweep.go:70 +0x9c fp=0xc00005f7d8 sp=0xc00005f7a8 pc=0x4254bc
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005f7e0 sp=0xc00005f7d8 pc=0x45ce41
created by runtime.gcenable
        /usr/lib/go-1.13/src/runtime/mgc.go:210 +0x5c

goroutine 4 [GC scavenge wait]:
runtime.gopark(0x9284f8, 0xc7cb40, 0x140d, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005ff38 sp=0xc00005ff18 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.bgscavenge(0xc000084000)
        /usr/lib/go-1.13/src/runtime/mgcscavenge.go:257 +0xe1 fp=0xc00005ffd8 sp=0xc00005ff38 pc=0x424b11
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005ffe0 sp=0xc00005ffd8 pc=0x45ce41
created by runtime.gcenable
        /usr/lib/go-1.13/src/runtime/mgc.go:211 +0x7e

goroutine 5 [finalizer wait]:
runtime.gopark(0x9284f8, 0xc99840, 0x1410, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005e758 sp=0xc00005e738 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.runfinq()
        /usr/lib/go-1.13/src/runtime/mfinal.go:175 +0xa3 fp=0xc00005e7e0 sp=0xc00005e758 pc=0x41b633
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005e7e8 sp=0xc00005e7e0 pc=0x45ce41
created by runtime.createfing
        /usr/lib/go-1.13/src/runtime/mfinal.go:156 +0x61

goroutine 6 [timer goroutine (idle)]:
runtime.gopark(0x9284f8, 0xc80f20, 0x1415, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000060760 sp=0xc000060740 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.timerproc(0xc80f20)
        /usr/lib/go-1.13/src/runtime/time.go:303 +0x27b fp=0xc0000607d8 sp=0xc000060760 pc=0x44decb
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0000607e0 sp=0xc0000607d8 pc=0x45ce41
created by runtime.(*timersBucket).addtimerLocked
        /usr/lib/go-1.13/src/runtime/time.go:169 +0x10e

goroutine 7 [chan send]:
runtime.gopark(0x9284f8, 0xc000086418, 0xc00010160f, 0x3)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00006ce50 sp=0xc00006ce30 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.chansend(0xc0000863c0, 0xc00010e040, 0xc00010e001, 0x7ef7ed, 0x1)
        /usr/lib/go-1.13/src/runtime/chan.go:236 +0x23b fp=0xc00006ced0 sp=0xc00006ce50 pc=0x40857b
runtime.chansend1(0xc0000863c0, 0xc00010e040)
        /usr/lib/go-1.13/src/runtime/chan.go:127 +0x35 fp=0xc00006cf08 sp=0xc00006ced0 pc=0x408335
github.com/jfreymuth/pulse/proto.(*Client).readLoop(0xc00010e010)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:101 +0x7bd fp=0xc00006cfd8 sp=0xc00006cf08 pc=0x7ef7ed
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00006cfe0 sp=0xc00006cfd8 pc=0x45ce41
created by github.com/jfreymuth/pulse/proto.(*Client).Open
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:44 +0x15f

goroutine 18 [IO wait]:
runtime.gopark(0x9284c8, 0x7f88a9da3f70, 0x1b02, 0x5)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000071ae0 sp=0xc000071ac0 pc=0x432780
runtime.netpollblock(0x7f88a9da3f48, 0x72, 0xc00003d780)
        /usr/lib/go-1.13/src/runtime/netpoll.go:397 +0x9a fp=0xc000071b18 sp=0xc000071ae0 pc=0x42d51a
internal/poll.runtime_pollWait(0x7f88a9da3f48, 0x72, 0xc0000ea9d0)
        /usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55 fp=0xc000071b40 sp=0xc000071b18 pc=0x42cae5
internal/poll.(*pollDesc).wait(0xc0001c6018, 0x72, 0xc0000ea900, 0x0, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45 fp=0xc000071b70 sp=0xc000071b40 pc=0x4b09e5
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).RawRead(0xc0001c6000, 0xc0000a7ce0, 0x0, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_unix.go:534 +0x10d fp=0xc000071be8 sp=0xc000071b70 pc=0x4b248d
net.(*rawConn).Read(0xc000130060, 0xc0000a7ce0, 0x1, 0x1)
        /usr/lib/go-1.13/src/net/rawconn.go:43 +0x56 fp=0xc000071c30 sp=0xc000071be8 pc=0x571616
golang.org/x/net/internal/socket.(*Conn).recvMsg(0xc0001aeee0, 0xc000071d88, 0x0, 0x0, 0xc000060db0)
        /home/lukas/go/pkg/mod/golang.org/x/net@v0.0.0-20191209160850-c0dbc17a3553/internal/socket/rawconn_msg.go:32 +0x20e fp=0xc000071cf0 sp=0xc000071c30 pc=0x6e3c8e
golang.org/x/net/internal/socket.(*Conn).RecvMsg(...)
        /home/lukas/go/pkg/mod/golang.org/x/net@v0.0.0-20191209160850-c0dbc17a3553/internal/socket/socket.go:255
golang.org/x/net/ipv4.(*payloadHandler).ReadFrom(0xc000136920, 0xc0001d2000, 0x200, 0x200, 0x880ea0, 0xc000026608, 0x8683e0, 0xc000026608, 0x45cefe, 0xc00010e020)
        /home/lukas/go/pkg/mod/golang.org/x/net@v0.0.0-20191209160850-c0dbc17a3553/ipv4/payload_cmsg.go:31 +0x1ac fp=0xc000071df0 sp=0xc000071cf0 pc=0x6e7e5c
github.com/pion/mdns.(*Conn).start(0xc0001c6280)
        /home/lukas/go/pkg/mod/github.com/pion/mdns@v0.0.4/conn.go:256 +0x14d fp=0xc000071fd8 sp=0xc000071df0 pc=0x6ec91d
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000071fe0 sp=0xc000071fd8 pc=0x45ce41
created by github.com/pion/mdns.Server
        /home/lukas/go/pkg/mod/github.com/pion/mdns@v0.0.4/conn.go:98 +0x487

goroutine 19 [select]:
runtime.gopark(0x928538, 0x0, 0x1809, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001f8d38 sp=0xc0001f8d18 pc=0x432780
runtime.selectgo(0xc0001f8eb0, 0xc0001f8e8c, 0x3, 0x1, 0x1)
        /usr/lib/go-1.13/src/runtime/select.go:313 +0xc9b fp=0xc0001f8e60 sp=0xc0001f8d38 pc=0x4414fb
github.com/pion/ice.(*Agent).taskLoop(0xc0001d0000)
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/agent.go:754 +0x249 fp=0xc0001f8fd8 sp=0xc0001f8e60 pc=0x70e739
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001f8fe0 sp=0xc0001f8fd8 pc=0x45ce41
created by github.com/pion/ice.NewAgent
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/agent.go:444 +0x8b3

goroutine 23 [timer goroutine (idle)]:
runtime.gopark(0x9284f8, 0xc80fa0, 0x1415, 0x1)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005b760 sp=0xc00005b740 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.timerproc(0xc80fa0)
        /usr/lib/go-1.13/src/runtime/time.go:303 +0x27b fp=0xc00005b7d8 sp=0xc00005b760 pc=0x44decb
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005b7e0 sp=0xc00005b7d8 pc=0x45ce41
created by runtime.(*timersBucket).addtimerLocked
        /usr/lib/go-1.13/src/runtime/time.go:169 +0x10e

goroutine 34 [IO wait]:
runtime.gopark(0x9284c8, 0x7f88a9da3ea0, 0x1b02, 0x5)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001f0470 sp=0xc0001f0450 pc=0x432780
runtime.netpollblock(0x7f88a9da3e78, 0x72, 0x0)
        /usr/lib/go-1.13/src/runtime/netpoll.go:397 +0x9a fp=0xc0001f04a8 sp=0xc0001f0470 pc=0x42d51a
internal/poll.runtime_pollWait(0x7f88a9da3e78, 0x72, 0x0)
        /usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55 fp=0xc0001f04d0 sp=0xc0001f04a8 pc=0x42cae5
internal/poll.(*pollDesc).wait(0xc0001c6898, 0x72, 0x2000, 0x2000, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45 fp=0xc0001f0500 sp=0xc0001f04d0 pc=0x4b09e5
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).ReadFrom(0xc0001c6880, 0xc000206000, 0x2000, 0x2000, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_unix.go:219 +0x1c3 fp=0xc0001f05b0 sp=0xc0001f0500 pc=0x4b1653
net.(*netFD).readFrom(0xc0001c6880, 0xc000206000, 0x2000, 0x2000, 0xc0001f06f0, 0x40f236, 0x7f88ae805d98, 0x65, 0xc000206000)
        /usr/lib/go-1.13/src/net/fd_unix.go:208 +0x5b fp=0xc0001f0630 sp=0xc0001f05b0 pc=0x55fe3b
net.(*UDPConn).readFrom(0xc000130070, 0xc000206000, 0x2000, 0x2000, 0x0, 0x0, 0xc0001f0720, 0x445cac)
        /usr/lib/go-1.13/src/net/udpsock_posix.go:47 +0x6a fp=0xc0001f06c0 sp=0xc0001f0630 pc=0x57848a
net.(*UDPConn).ReadFrom(0xc000130070, 0xc000206000, 0x2000, 0x2000, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.13/src/net/udpsock.go:121 +0x5d fp=0xc0001f0730 sp=0xc0001f06c0 pc=0x576dbd
github.com/pion/ice.(*candidateBase).recvLoop(0xc000158820)
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/candidate_base.go:92 +0x14b fp=0xc0001f07d8 sp=0xc0001f0730 pc=0x71286b
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001f07e0 sp=0xc0001f07d8 pc=0x45ce41
created by github.com/pion/ice.(*candidateBase).start
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/candidate_base.go:81 +0xe0

goroutine 24 [IO wait]:
runtime.gopark(0x9284c8, 0x7f88a9da3dd0, 0x1b02, 0x5)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005ac70 sp=0xc00005ac50 pc=0x432780
runtime.netpollblock(0x7f88a9da3da8, 0x72, 0x0)
        /usr/lib/go-1.13/src/runtime/netpoll.go:397 +0x9a fp=0xc00005aca8 sp=0xc00005ac70 pc=0x42d51a
internal/poll.runtime_pollWait(0x7f88a9da3da8, 0x72, 0x0)
        /usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55 fp=0xc00005acd0 sp=0xc00005aca8 pc=0x42cae5
internal/poll.(*pollDesc).wait(0xc0001c6918, 0x72, 0x2000, 0x2000, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45 fp=0xc00005ad00 sp=0xc00005acd0 pc=0x4b09e5
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).ReadFrom(0xc0001c6900, 0xc00021a000, 0x2000, 0x2000, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.13/src/internal/poll/fd_unix.go:219 +0x1c3 fp=0xc00005adb0 sp=0xc00005ad00 pc=0x4b1653
net.(*netFD).readFrom(0xc0001c6900, 0xc00021a000, 0x2000, 0x2000, 0xc00005aef0, 0x40f236, 0x7f88ae8056d0, 0xc000086065, 0xc00021a000)
        /usr/lib/go-1.13/src/net/fd_unix.go:208 +0x5b fp=0xc00005ae30 sp=0xc00005adb0 pc=0x55fe3b
net.(*UDPConn).readFrom(0xc0001300a0, 0xc00021a000, 0x2000, 0x2000, 0xc00011a5a0, 0xc00005af70, 0xc00005af20, 0x445cac)
        /usr/lib/go-1.13/src/net/udpsock_posix.go:47 +0x6a fp=0xc00005aec0 sp=0xc00005ae30 pc=0x57848a
net.(*UDPConn).ReadFrom(0xc0001300a0, 0xc00021a000, 0x2000, 0x2000, 0xc000186e00, 0x12, 0x0, 0x0, 0xc0001e6510)
        /usr/lib/go-1.13/src/net/udpsock.go:121 +0x5d fp=0xc00005af30 sp=0xc00005aec0 pc=0x576dbd
github.com/pion/ice.(*candidateBase).recvLoop(0xc0000ca510)
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/candidate_base.go:92 +0x14b fp=0xc00005afd8 sp=0xc00005af30 pc=0x71286b
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005afe0 sp=0xc00005afd8 pc=0x45ce41
created by github.com/pion/ice.(*candidateBase).start
        /home/lukas/go/pkg/mod/github.com/pion/ice@v0.7.8/candidate_base.go:81 +0xe0

goroutine 10 [chan send]:
runtime.gopark(0x9284f8, 0xc0000867d8, 0xc00010160f, 0x3)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001fae50 sp=0xc0001fae30 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.chansend(0xc000086780, 0xc00010e140, 0xc00010e101, 0x7ef7ed, 0x1)
        /usr/lib/go-1.13/src/runtime/chan.go:236 +0x23b fp=0xc0001faed0 sp=0xc0001fae50 pc=0x40857b
runtime.chansend1(0xc000086780, 0xc00010e140)
        /usr/lib/go-1.13/src/runtime/chan.go:127 +0x35 fp=0xc0001faf08 sp=0xc0001faed0 pc=0x408335
github.com/jfreymuth/pulse/proto.(*Client).readLoop(0xc00010e110)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:101 +0x7bd fp=0xc0001fafd8 sp=0xc0001faf08 pc=0x7ef7ed
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001fafe0 sp=0xc0001fafd8 pc=0x45ce41
created by github.com/jfreymuth/pulse/proto.(*Client).Open
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:44 +0x15f

goroutine 11 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc0000266f0, 0xc0000c1418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000060f60 sp=0xc000060f40 pc=0x432780
runtime.gcBgMarkWorker(0xc000042a00)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc000060fd8 sp=0xc000060f60 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000060fe0 sp=0xc000060fd8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 35 [syscall]:
runtime.notetsleepg(0xc7d6d8, 0xffffffffffffffff, 0xc00004c000)
        /usr/lib/go-1.13/src/runtime/lock_futex.go:227 +0x34 fp=0xc0001f9b30 sp=0xc0001f9b00 pc=0x40e014
runtime.gcBgMarkStartWorkers()
        /usr/lib/go-1.13/src/runtime/mgc.go:1786 +0x90 fp=0xc0001f9b70 sp=0xc0001f9b30 pc=0x41ed50
runtime.gcStart(0x0, 0x0, 0xc000000000)
        /usr/lib/go-1.13/src/runtime/mgc.go:1265 +0x197 fp=0xc0001f9be0 sp=0xc0001f9b70 pc=0x41d9d7
runtime.mallocgc(0x500, 0x84bca0, 0x1, 0x5365)
        /usr/lib/go-1.13/src/runtime/malloc.go:1115 +0x416 fp=0xc0001f9c80 sp=0xc0001f9be0 pc=0x40f336
runtime.makeslice(0x84bca0, 0x4a4, 0x4a4, 0xc00046d900)
        /usr/lib/go-1.13/src/runtime/slice.go:49 +0x6c fp=0xc0001f9cb0 sp=0xc0001f9c80 pc=0x445cac
github.com/pion/rtp/codecs.(*H264Payloader).Payload.func1(0xc0004262e1, 0x629c, 0x3fd1f)
        /home/lukas/go/pkg/mod/github.com/pion/rtp@v1.3.2/codecs/h264_packet.go:94 +0x127 fp=0xc0001f9d50 sp=0xc0001f9cb0 pc=0x728277
github.com/pion/rtp/codecs.emitNalus(0xc000426000, 0x2f45b, 0x40000, 0xc0001f9de0)
        /home/lukas/go/pkg/mod/github.com/pion/rtp@v1.3.2/codecs/h264_packet.go:36 +0x124 fp=0xc0001f9da8 sp=0xc0001f9d50 pc=0x7275d4
github.com/pion/rtp/codecs.(*H264Payloader).Payload(0xc998e8, 0x4a4, 0xc000426000, 0x2f45b, 0x40000, 0xc0001f9e58, 0x441d6e, 0xc000224134)
        /home/lukas/go/pkg/mod/github.com/pion/rtp@v1.3.2/codecs/h264_packet.go:52 +0x98 fp=0xc0001f9e08 sp=0xc0001f9da8 pc=0x727718
github.com/pion/rtp.(*packetizer).Packetize(0xc00021e370, 0xc000426000, 0x2f45b, 0x40000, 0x7f8800009568, 0x7f88ab5e0e70, 0x3e075, 0x2)
        /home/lukas/go/pkg/mod/github.com/pion/rtp@v1.3.2/packetizer.go:75 +0x85 fp=0xc0001f9ea8 sp=0xc0001f9e08 pc=0x6d2955
github.com/pion/webrtc/v2.(*Track).WriteSample(0xc00023e120, 0xc000426000, 0x2f45b, 0x40000, 0x100009568, 0xc7ce20, 0x1954ba80)
        /home/lukas/go/pkg/mod/github.com/pion/webrtc/v2@v2.2.0/track.go:133 +0x64 fp=0xc0001f9f10 sp=0xc0001f9ea8 pc=0x775864
github.com/pion/mediadevices.(*sampler).sample(0xc000220630, 0xc000426000, 0x2f45b, 0x40000, 0x2f45b, 0x0)
        /home/lukas/Documents/pion/mediadevices/sampler.go:30 +0x11e fp=0xc0001f9f78 sp=0xc0001f9f10 pc=0x77ea2e
github.com/pion/mediadevices.(*videoTrack).start(0xc0002261a0)
        /home/lukas/Documents/pion/mediadevices/track.go:173 +0x13e fp=0xc0001f9fd8 sp=0xc0001f9f78 pc=0x77f70e
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001f9fe0 sp=0xc0001f9fd8 pc=0x45ce41
created by github.com/pion/mediadevices.newVideoTrack
        /home/lukas/Documents/pion/mediadevices/track.go:153 +0x353

goroutine 36 [chan send]:
runtime.gopark(0x9284f8, 0xc000222178, 0xc00025160f, 0x3)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000061650 sp=0xc000061630 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.chansend(0xc000222120, 0xc00025e040, 0xc00025e001, 0x7ef7ed, 0x1)
        /usr/lib/go-1.13/src/runtime/chan.go:236 +0x23b fp=0xc0000616d0 sp=0xc000061650 pc=0x40857b
runtime.chansend1(0xc000222120, 0xc00025e040)
        /usr/lib/go-1.13/src/runtime/chan.go:127 +0x35 fp=0xc000061708 sp=0xc0000616d0 pc=0x408335
github.com/jfreymuth/pulse/proto.(*Client).readLoop(0xc00025e010)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:101 +0x7bd fp=0xc0000617d8 sp=0xc000061708 pc=0x7ef7ed
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0000617e0 sp=0xc0000617d8 pc=0x45ce41
created by github.com/jfreymuth/pulse/proto.(*Client).Open
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:44 +0x15f

goroutine 37 [chan send]:
runtime.gopark(0x9284f8, 0xc0002224d8, 0x160f, 0x3)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001fbce8 sp=0xc0001fbcc8 pc=0x432780
runtime.goparkunlock(...)
        /usr/lib/go-1.13/src/runtime/proc.go:310
runtime.chansend(0xc000222480, 0xc0001fbdb0, 0x1, 0x7f9232, 0x0)
        /usr/lib/go-1.13/src/runtime/chan.go:236 +0x23b fp=0xc0001fbd68 sp=0xc0001fbce8 pc=0x40857b
runtime.chansend1(0xc000222480, 0xc0001fbdb0)
        /usr/lib/go-1.13/src/runtime/chan.go:127 +0x35 fp=0xc0001fbda0 sp=0xc0001fbd68 pc=0x408335
github.com/pion/mediadevices/pkg/driver/microphone.(*microphone).AudioRecord.func1(0xc000285000, 0x1e0, 0x1e0)
        /home/lukas/Documents/pion/mediadevices/pkg/driver/microphone/microphone_linux.go:93 +0x52 fp=0xc0001fbdd8 sp=0xc0001fbda0 pc=0x7f9232
github.com/jfreymuth/pulse.(*RecordStream).write(0xc00026e000, 0xc000285000, 0x780, 0xf00)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/record.go:92 +0xf7 fp=0xc0001fbe90 sp=0xc0001fbdd8 pc=0x7f6ea7
github.com/jfreymuth/pulse.NewClient.func1(0x833ba0, 0xc0001af3a0)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/client.go:94 +0x116 fp=0xc0001fbf08 sp=0xc0001fbe90 pc=0x7f7f86
github.com/jfreymuth/pulse/proto.(*Client).readLoop(0xc00025e210)
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:175 +0x163 fp=0xc0001fbfd8 sp=0xc0001fbf08 pc=0x7ef193
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001fbfe0 sp=0xc0001fbfd8 pc=0x45ce41
created by github.com/jfreymuth/pulse/proto.(*Client).Open
        /home/lukas/go/pkg/mod/github.com/jfreymuth/pulse@v0.0.0-20200118113426-7cf5f487291e/proto/client.go:44 +0x15f

goroutine 25 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc0000266e0, 0xc000051418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc00005a760 sp=0xc00005a740 pc=0x432780
runtime.gcBgMarkWorker(0xc000040500)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc00005a7d8 sp=0xc00005a760 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00005a7e0 sp=0xc00005a7d8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 39 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc000229130, 0x1418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001f0f60 sp=0xc0001f0f40 pc=0x432780
runtime.gcBgMarkWorker(0xc00003e000)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc0001f0fd8 sp=0xc0001f0f60 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001f0fe0 sp=0xc0001f0fd8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 12 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc000026700, 0x1418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000061f60 sp=0xc000061f40 pc=0x432780
runtime.gcBgMarkWorker(0xc000044f00)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc000061fd8 sp=0xc000061f60 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000061fe0 sp=0xc000061fd8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 50 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc000026710, 0x1418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc0001ec760 sp=0xc0001ec740 pc=0x432780
runtime.gcBgMarkWorker(0xc000047400)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc0001ec7d8 sp=0xc0001ec760 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001ec7e0 sp=0xc0001ec7d8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 13 [GC worker (idle)]:
runtime.gopark(0x928398, 0xc000484000, 0x1418, 0x0)
        /usr/lib/go-1.13/src/runtime/proc.go:304 +0xe0 fp=0xc000480760 sp=0xc000480740 pc=0x432780
runtime.gcBgMarkWorker(0xc000049900)
        /usr/lib/go-1.13/src/runtime/mgc.go:1837 +0xff fp=0xc0004807d8 sp=0xc000480760 pc=0x41ee8f
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0004807e0 sp=0xc0004807d8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

goroutine 51 [runnable]:
runtime.gcBgMarkWorker(0xc00004c000)
        /usr/lib/go-1.13/src/runtime/mgc.go:1808 fp=0xc0001ecfd8 sp=0xc0001ecfd0 pc=0x41ed90
runtime.goexit()
        /usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001ecfe0 sp=0xc0001ecfd8 pc=0x45ce41
created by runtime.gcBgMarkStartWorkers
        /usr/lib/go-1.13/src/runtime/mgc.go:1785 +0x77

rax    0x0
rbx    0x7f88abde2700
rcx    0x7f88ae9e53eb
rdx    0x0
rdi    0x2
rsi    0x7f88abde1a40
rbp    0x7f88abde1d90
rsp    0x7f88abde1a40
r8     0x0
r9     0x7f88abde1a40
r10    0x8
r11    0x246
r12    0x7f88abde1cb0
r13    0x10
r14    0x7f88af14f000
r15    0x2
rip    0x7f88ae9e53eb
rflags 0x246
cs     0x33
fs     0x0
gs     0x0
exit status 2
```


#### Reference issue
Fixes #...
