### PR TITLE
codec/vaapi: return error on unsupported environment

### DIFF
--- a/pkg/codec/vaapi/vaapi.go
+++ b/pkg/codec/vaapi/vaapi.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 // Package vaapi implements hardware accelerated codecs.
 // This package requires libva headers and libraries to be built.
 // libva requires supported graphic card and its driver.

--- a/pkg/codec/vaapi/vaapi_unsupported.go
+++ b/pkg/codec/vaapi/vaapi_unsupported.go
@@ -1,0 +1,24 @@
+// +build !dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package vaapi
+
+// // Dummy CGO import to avoid `C source files not allowed when not using cgo or SWIG`
+import "C"
+
+import (
+	"errors"
+
+	"github.com/pion/mediadevices/pkg/codec"
+	"github.com/pion/mediadevices/pkg/io/video"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+var errNotSupported = errors.New("vaapi is not supported on this environment")
+
+func newVP8Encoder(r video.Reader, p prop.Media, params ParamsVP8) (codec.ReadCloser, error) {
+	return nil, errNotSupported
+}
+
+func newVP9Encoder(r video.Reader, p prop.Media, params ParamsVP9) (codec.ReadCloser, error) {
+	return nil, errNotSupported
+}

--- a/pkg/codec/vaapi/vp8.go
+++ b/pkg/codec/vaapi/vp8.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 package vaapi
 
 // reference: https://github.com/intel/libva-utils/blob/master/encode/vp8enc.c

--- a/pkg/codec/vaapi/vp9.go
+++ b/pkg/codec/vaapi/vp9.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 package vaapi
 
 // reference: https://github.com/intel/libva-utils/blob/master/encode/vp9enc.c


### PR DESCRIPTION
Make it buildable on unsupported environment.
Return error on runtime.
