### PR TITLE
codec/vaapi: return error on unsupported environment

### DIFF
--- a/pkg/codec/vaapi/helper.c
+++ b/pkg/codec/vaapi/helper.c
@@ -1,3 +1,5 @@
+#ifdef HAS_VAAPI
+
 #include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
@@ -48,3 +50,5 @@ void copyI420toNV12(
     p[i * 2 + 1] = cr[i];
   }
 }
+
+#endif // HAS_VAAPI

--- a/pkg/codec/vaapi/helper.h
+++ b/pkg/codec/vaapi/helper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef HAS_VAAPI
+
 #include <unistd.h>
 #include <va/va.h>
 
@@ -15,3 +17,5 @@ void copyI420toNV12(
     void *nv12,
     const uint8_t *y, const uint8_t *cb, const uint8_t *cr,
     const unsigned int n);
+
+#endif // HAS_VAAPI

--- a/pkg/codec/vaapi/vaapi.go
+++ b/pkg/codec/vaapi/vaapi.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 // Package vaapi implements hardware accelerated codecs.
 // This package requires libva headers and libraries to be built.
 // libva requires supported graphic card and its driver.
@@ -8,6 +10,8 @@ import (
 	"unsafe"
 )
 
+// #cgo pkg-config: libva libva-drm
+// #cgo CFLAGS: -DHAS_VAAPI
 // #include <stdlib.h>
 // #include <fcntl.h>
 // #include <unistd.h>

--- a/pkg/codec/vaapi/vaapi_unsupported.go
+++ b/pkg/codec/vaapi/vaapi_unsupported.go
@@ -1,0 +1,24 @@
+// +build !dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package vaapi
+
+// // Dummy CGO import to avoid `C source files not allowed when not using cgo or SWIG`
+import "C"
+
+import (
+	"errors"
+
+	"github.com/pion/mediadevices/pkg/codec"
+	"github.com/pion/mediadevices/pkg/io/video"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+var errNotSupported = errors.New("vaapi is not supported on this environment")
+
+func newVP8Encoder(r video.Reader, p prop.Media, params ParamsVP8) (codec.ReadCloser, error) {
+	return nil, errNotSupported
+}
+
+func newVP9Encoder(r video.Reader, p prop.Media, params ParamsVP9) (codec.ReadCloser, error) {
+	return nil, errNotSupported
+}

--- a/pkg/codec/vaapi/vp8.go
+++ b/pkg/codec/vaapi/vp8.go
@@ -1,8 +1,9 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 package vaapi
 
 // reference: https://github.com/intel/libva-utils/blob/master/encode/vp8enc.c
 
-// #cgo pkg-config: libva libva-drm
 // #include <fcntl.h>
 // #include <stdint.h>
 // #include <stdio.h>

--- a/pkg/codec/vaapi/vp9.go
+++ b/pkg/codec/vaapi/vp9.go
@@ -1,8 +1,9 @@
+// +build dragonfly freebsd linux netbsd openbsd solaris
+
 package vaapi
 
 // reference: https://github.com/intel/libva-utils/blob/master/encode/vp9enc.c
 
-// #cgo pkg-config: libva libva-drm
 // #include <fcntl.h>
 // #include <stdint.h>
 // #include <stdio.h>


### PR DESCRIPTION
Make it buildable on unsupported environment.
Return error on runtime.
