### PR TITLE
Harden driver's property requirement check

### DIFF
--- a/pkg/driver/wrapper.go
+++ b/pkg/driver/wrapper.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"fmt"
+
 	"github.com/pion/mediadevices/pkg/io/audio"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
@@ -78,8 +80,21 @@ func (w *adapterWrapper) Properties() []prop.Media {
 	return p
 }
 
+func isPropertySupported(haveProps []prop.Media, wantProp prop.Media) error {
+	for _, haveProp := range haveProps {
+		if haveProp == wantProp {
+			return nil
+		}
+	}
+	return fmt.Errorf("Want %v but have: %v", wantProp, haveProps)
+}
+
 func (w *adapterWrapper) VideoRecord(p prop.Media) (r video.Reader, err error) {
 	err = w.state.Update(StateRunning, func() error {
+		err = isPropertySupported(w.Properties(), p)
+		if err != nil {
+			return err
+		}
 		r, err = w.VideoRecorder.VideoRecord(p)
 		return err
 	})
@@ -91,6 +106,10 @@ func (w *adapterWrapper) VideoRecord(p prop.Media) (r video.Reader, err error) {
 
 func (w *adapterWrapper) AudioRecord(p prop.Media) (r audio.Reader, err error) {
 	err = w.state.Update(StateRunning, func() error {
+		err = isPropertySupported(w.Properties(), p)
+		if err != nil {
+			return err
+		}
 		r, err = w.AudioRecorder.AudioRecord(p)
 		return err
 	})

--- a/pkg/driver/wrapper_test.go
+++ b/pkg/driver/wrapper_test.go
@@ -3,7 +3,9 @@ package driver
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/pion/mediadevices/pkg/frame"
 	"github.com/pion/mediadevices/pkg/io/audio"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
@@ -17,7 +19,7 @@ type adapterMock struct{}
 
 func (a *adapterMock) Open() error              { return nil }
 func (a *adapterMock) Close() error             { return nil }
-func (a *adapterMock) Properties() []prop.Media { return []prop.Media{prop.Media{}} }
+func (a *adapterMock) Properties() []prop.Media { return []prop.Media{{}} }
 
 type videoAdapterMock struct{ adapterMock }
 
@@ -29,6 +31,15 @@ func (a *videoAdapterBrokenMock) VideoRecord(p prop.Media) (r video.Reader, err 
 	return nil, recordErr
 }
 
+type videoAdapterWithProperties struct {
+	videoAdapterMock
+	properties []prop.Media
+}
+
+func (a *videoAdapterWithProperties) Properties() []prop.Media {
+	return a.properties
+}
+
 type audioAdapterMock struct{ adapterMock }
 
 func (a *audioAdapterMock) AudioRecord(p prop.Media) (r audio.Reader, err error) { return nil, nil }
@@ -37,6 +48,15 @@ type audioAdapterBrokenMock struct{ adapterMock }
 
 func (a *audioAdapterBrokenMock) AudioRecord(p prop.Media) (r audio.Reader, err error) {
 	return nil, recordErr
+}
+
+type audioAdapterWithProperties struct {
+	audioAdapterMock
+	properties []prop.Media
+}
+
+func (a *audioAdapterWithProperties) Properties() []prop.Media {
+	return a.properties
 }
 
 func TestVideoWrapperState(t *testing.T) {
@@ -58,7 +78,7 @@ func TestVideoWrapperState(t *testing.T) {
 		t.Errorf("expected to successfully open, but got %v", err)
 	}
 
-	_, err = vr.VideoRecord(prop.Media{})
+	_, err = vr.VideoRecord(d.Properties()[0])
 	if err != nil {
 		t.Errorf("expected to successfully start recording, but got %v", err)
 	}
@@ -74,7 +94,7 @@ func TestVideoWrapperWithBrokenRecorderState(t *testing.T) {
 	}
 
 	vr := d.(VideoRecorder)
-	_, err = vr.VideoRecord(prop.Media{})
+	_, err = vr.VideoRecord(d.Properties()[0])
 	if err == nil {
 		t.Errorf("expected to get an error")
 	}
@@ -85,6 +105,85 @@ func TestVideoWrapperWithBrokenRecorderState(t *testing.T) {
 
 	if d.Status() != StateClosed {
 		t.Errorf("expected the status to be %v, but got %v", StateClosed, d.Status())
+	}
+}
+
+func TestVideoWrapperWithProperties(t *testing.T) {
+	var a videoAdapterWithProperties
+	newProp := func(width, height int, frameRate float32, frameFormat frame.Format) prop.Media {
+		var p prop.Media
+		p.Width = width
+		p.Height = height
+		p.FrameRate = frameRate
+		p.FrameFormat = frameFormat
+		return p
+	}
+	cases := map[string]struct {
+		haveProps []prop.Media
+		wantProp  prop.Media
+		expectErr bool
+	}{
+		"Invalid prop 1": {
+			haveProps: []prop.Media{
+				newProp(2, 2, 3.0, frame.FormatI420),
+			},
+			wantProp:  newProp(1, 2, 3.0, frame.FormatI420),
+			expectErr: true,
+		},
+		"Invalid prop 2": {
+			haveProps: []prop.Media{
+				newProp(1, 2, 4.0, frame.FormatI420),
+			},
+			wantProp:  newProp(1, 2, 3.0, frame.FormatI420),
+			expectErr: true,
+		},
+		"Invalid prop 3": {
+			haveProps: []prop.Media{
+				newProp(1, 2, 3.0, frame.FormatI444),
+			},
+			wantProp:  newProp(1, 2, 3.0, frame.FormatI420),
+			expectErr: true,
+		},
+		"Invalid prop 4": {
+			haveProps: nil,
+			wantProp:  newProp(1, 2, 3.0, frame.FormatI420),
+			expectErr: true,
+		},
+		"Valid prop": {
+			haveProps: []prop.Media{
+				newProp(1, 2, 3.0, frame.FormatI420),
+			},
+			wantProp:  newProp(1, 2, 3.0, frame.FormatI420),
+			expectErr: false,
+		},
+	}
+
+	d := wrapAdapter(&a, Info{})
+	ar := d.(VideoRecorder)
+	for testCaseName, testCase := range cases {
+		t.Run(testCaseName, func(t *testing.T) {
+			err := d.Open()
+			if err != nil {
+				t.Fatalf("expect to open successfully. But, failed with %s", err)
+			}
+
+			a.properties = testCase.haveProps
+			// TODO: Find a better way to get the device id
+			var deviceID string
+			if len(d.Properties()) > 0 {
+				deviceID = d.Properties()[0].DeviceID
+			}
+			testCase.wantProp.DeviceID = deviceID
+			_, err = ar.VideoRecord(testCase.wantProp)
+			if testCase.expectErr && err == nil {
+				t.Fatalf("expect an error but got nil")
+			} else if !testCase.expectErr && err != nil {
+				t.Fatalf("expect no error but got %s", err)
+			} else if !testCase.expectErr {
+				// since it successfully opened, we need to close it
+				d.Close()
+			}
+		})
 	}
 }
 
@@ -107,7 +206,7 @@ func TestAudioWrapperState(t *testing.T) {
 		t.Errorf("expected to successfully open, but got %v", err)
 	}
 
-	_, err = ar.AudioRecord(prop.Media{})
+	_, err = ar.AudioRecord(d.Properties()[0])
 	if err != nil {
 		t.Errorf("expected to successfully start recording, but got %v", err)
 	}
@@ -123,7 +222,7 @@ func TestAudioWrapperWithBrokenRecorderState(t *testing.T) {
 	}
 
 	ar := d.(AudioRecorder)
-	_, err = ar.AudioRecord(prop.Media{})
+	_, err = ar.AudioRecord(d.Properties()[0])
 	if err == nil {
 		t.Errorf("expected to get an error")
 	}
@@ -134,5 +233,77 @@ func TestAudioWrapperWithBrokenRecorderState(t *testing.T) {
 
 	if d.Status() != StateClosed {
 		t.Errorf("expected the status to be %v, but got %v", StateClosed, d.Status())
+	}
+}
+
+func TestAudioWrapperWithProperties(t *testing.T) {
+	newProp := func(channelCount int, latency time.Duration, sampleRate int, sampleSize int) prop.Media {
+		var p prop.Media
+		p.ChannelCount = channelCount
+		p.Latency = latency
+		p.SampleRate = sampleRate
+		p.SampleSize = sampleSize
+		return p
+	}
+	cases := map[string]struct {
+		haveProps []prop.Media
+		wantProp  prop.Media
+		expectErr bool
+	}{
+		"Invalid prop 1": {
+			haveProps: []prop.Media{
+				newProp(1, time.Second, 3, 5),
+			},
+			wantProp:  newProp(1, time.Second, 3, 4),
+			expectErr: true,
+		},
+		"Invalid prop 2": {
+			haveProps: []prop.Media{
+				newProp(1, time.Minute, 3, 4),
+			},
+			wantProp:  newProp(1, time.Second, 3, 4),
+			expectErr: true,
+		},
+		"Invalid prop 3": {
+			haveProps: nil,
+			wantProp:  newProp(1, time.Second, 3, 4),
+			expectErr: true,
+		},
+		"Valid prop": {
+			haveProps: []prop.Media{
+				newProp(1, time.Second, 3, 4),
+			},
+			wantProp:  newProp(1, time.Second, 3, 4),
+			expectErr: false,
+		},
+	}
+
+	var a audioAdapterWithProperties
+	d := wrapAdapter(&a, Info{})
+	ar := d.(AudioRecorder)
+	for testCaseName, testCase := range cases {
+		t.Run(testCaseName, func(t *testing.T) {
+			err := d.Open()
+			if err != nil {
+				t.Fatalf("expect to open successfully. But, failed with %s", err)
+			}
+
+			a.properties = testCase.haveProps
+			// TODO: Find a better way to get the device id
+			var deviceID string
+			if len(d.Properties()) > 0 {
+				deviceID = d.Properties()[0].DeviceID
+			}
+			testCase.wantProp.DeviceID = deviceID
+			_, err = ar.AudioRecord(testCase.wantProp)
+			if testCase.expectErr && err == nil {
+				t.Fatalf("expect an error but got nil")
+			} else if !testCase.expectErr && err != nil {
+				t.Fatalf("expect no error but got %s", err)
+			} else if !testCase.expectErr {
+				// since it successfully opened, we need to close it
+				d.Close()
+			}
+		})
 	}
 }


### PR DESCRIPTION
Make sure that the property that's given to the adapter is matched to one of the properties that the adapter provided. If none matched, the state would change to Close.