### PR TITLE
Skip time related tests for Darwin

### DIFF
--- a/pkg/io/video/detect_test.go
+++ b/pkg/io/video/detect_test.go
@@ -3,6 +3,7 @@ package video
 import (
 	"fmt"
 	"image"
+	"runtime"
 	"testing"
 	"time"
 
@@ -123,6 +124,11 @@ func TestDetectChanges(t *testing.T) {
 	})
 
 	t.Run("FrameRateAccuracy", func(t *testing.T) {
+		// https://github.com/pion/mediadevices/issues/198
+		if runtime.GOOS == "darwin" {
+			t.Skip("Skipping because Darwin CI is not reliable for timing related tests.")
+		}
+
 		var expected prop.Media
 		var actual prop.Media
 		var count int

--- a/pkg/io/video/throttle_test.go
+++ b/pkg/io/video/throttle_test.go
@@ -2,11 +2,16 @@ package video
 
 import (
 	"image"
+	"runtime"
 	"testing"
 	"time"
 )
 
 func TestThrottle(t *testing.T) {
+	// https://github.com/pion/mediadevices/issues/198
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping because Darwin CI is not reliable for timing related tests.")
+	}
 	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
 
 	ticker := time.NewTicker(20 * time.Millisecond)


### PR DESCRIPTION
This is a temporary workaround for https://github.com/pion/mediadevices/issues/198.