### PR TITLE
Add V4L2_PIX_FMT_YUV420 support for Linux

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -57,10 +57,11 @@ func init() {
 
 func newCamera(path string) *camera {
 	formats := map[webcam.PixelFormat]frame.Format{
-		webcam.PixelFormat(C.V4L2_PIX_FMT_YUYV):  frame.FormatYUYV,
-		webcam.PixelFormat(C.V4L2_PIX_FMT_UYVY):  frame.FormatUYVY,
-		webcam.PixelFormat(C.V4L2_PIX_FMT_NV12):  frame.FormatNV21,
-		webcam.PixelFormat(C.V4L2_PIX_FMT_MJPEG): frame.FormatMJPEG,
+		webcam.PixelFormat(C.V4L2_PIX_FMT_YUV420): frame.FormatI420,
+		webcam.PixelFormat(C.V4L2_PIX_FMT_YUYV):   frame.FormatYUYV,
+		webcam.PixelFormat(C.V4L2_PIX_FMT_UYVY):   frame.FormatUYVY,
+		webcam.PixelFormat(C.V4L2_PIX_FMT_NV12):   frame.FormatNV21,
+		webcam.PixelFormat(C.V4L2_PIX_FMT_MJPEG):  frame.FormatMJPEG,
 	}
 
 	reversedFormats := make(map[frame.Format]webcam.PixelFormat)


### PR DESCRIPTION
According to https://www.kernel.org/doc/html/v4.10/media/uapi/v4l/pixfmt-yuv420.html, YU12 is equal to V4L2_PIX_FMT_YUV420 in v4l2 term. In fourcc, V4L2_PIX_FMT_YUV420 is equal to I420, V4L2_PIX_FMT_YUV420.

