### PR TITLE
Remove webrtc dependency in codec and its sub packages

### DIFF
--- a/mediadevices_test.go
+++ b/mediadevices_test.go
@@ -161,8 +161,8 @@ type mockParams struct {
 	name string
 }
 
-func (params *mockParams) Name() string {
-	return params.name
+func (params *mockParams) Name() codec.Name {
+	return codec.Name(params.name)
 }
 
 func (params *mockParams) BuildVideoEncoder(r video.Reader, p prop.Media) (codec.ReadCloser, error) {

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -8,6 +8,17 @@ import (
 	"github.com/pion/mediadevices/pkg/prop"
 )
 
+// Name represents codec official name. It's possible to have more than 1 implementations
+// for the same codec name, e.g. openh264 vs x264.
+type Name string
+
+const (
+	NameOpus Name = "opus"
+	NameH264 Name = "H264"
+	NameVP8  Name = "VP8"
+	NameVP9  Name = "VP9"
+)
+
 // AudioEncoderBuilder is the interface that wraps basic operations that are
 // necessary to build the audio encoder.
 //
@@ -15,7 +26,7 @@ import (
 // but still giving generality for the users.
 type AudioEncoderBuilder interface {
 	// Name represents the codec name
-	Name() string
+	Name() Name
 	// BuildAudioEncoder builds audio encoder by given media params and audio input
 	BuildAudioEncoder(r audio.Reader, p prop.Media) (ReadCloser, error)
 }
@@ -27,7 +38,7 @@ type AudioEncoderBuilder interface {
 // but still giving generality for the users.
 type VideoEncoderBuilder interface {
 	// Name represents the codec name
-	Name() string
+	Name() Name
 	// BuildVideoEncoder builds video encoder by given media params and video input
 	BuildVideoEncoder(r video.Reader, p prop.Media) (ReadCloser, error)
 }

--- a/pkg/codec/openh264/params.go
+++ b/pkg/codec/openh264/params.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
-	"github.com/pion/webrtc/v2"
 )
 
 // Params stores libopenh264 specific encoding parameters.
@@ -22,8 +21,8 @@ func NewParams() (Params, error) {
 }
 
 // Name represents the codec name
-func (p *Params) Name() string {
-	return webrtc.H264
+func (p *Params) Name() codec.Name {
+	return codec.NameH264
 }
 
 // BuildVideoEncoder builds openh264 encoder with given params

--- a/pkg/codec/opus/params.go
+++ b/pkg/codec/opus/params.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pion/mediadevices/pkg/io/audio"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave/mixer"
-	"github.com/pion/webrtc/v2"
 )
 
 // Params stores opus specific encoding parameters.
@@ -21,8 +20,8 @@ func NewParams() (Params, error) {
 }
 
 // Name represents the codec name
-func (p *Params) Name() string {
-	return webrtc.Opus
+func (p *Params) Name() codec.Name {
+	return codec.NameOpus
 }
 
 // BuildAudioEncoder builds opus encoder with given params

--- a/pkg/codec/vaapi/params.go
+++ b/pkg/codec/vaapi/params.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
-	"github.com/pion/webrtc/v2"
 )
 
 // ParamsVP8 stores VP8 encoding parameters.
@@ -45,8 +44,8 @@ func NewVP8Params() (ParamsVP8, error) {
 }
 
 // Name represents the codec name
-func (p *ParamsVP8) Name() string {
-	return webrtc.VP8
+func (p *ParamsVP8) Name() codec.Name {
+	return codec.NameVP8
 }
 
 // BuildVideoEncoder builds VP8 encoder with given params
@@ -114,8 +113,8 @@ func NewVP9Params() (ParamsVP9, error) {
 }
 
 // Name represents the codec name
-func (p *ParamsVP9) Name() string {
-	return webrtc.VP9
+func (p *ParamsVP9) Name() codec.Name {
+	return codec.NameVP9
 }
 
 // BuildVideoEncoder builds VP9 encoder with given params

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -59,7 +59,6 @@ import (
 	mio "github.com/pion/mediadevices/pkg/io"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
-	"github.com/pion/webrtc/v2"
 )
 
 type encoder struct {
@@ -96,8 +95,8 @@ func NewVP8Params() (VP8Params, error) {
 }
 
 // Name represents the codec name
-func (p *VP8Params) Name() string {
-	return webrtc.VP8
+func (p *VP8Params) Name() codec.Name {
+	return codec.NameVP8
 }
 
 // BuildVideoEncoder builds VP8 encoder with given params
@@ -123,8 +122,8 @@ func NewVP9Params() (VP9Params, error) {
 }
 
 // Name represents the codec name
-func (p *VP9Params) Name() string {
-	return webrtc.VP9
+func (p *VP9Params) Name() codec.Name {
+	return codec.NameVP9
 }
 
 // BuildVideoEncoder builds VP9 encoder with given params

--- a/pkg/codec/x264/params.go
+++ b/pkg/codec/x264/params.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
-	"github.com/pion/webrtc/v2"
 )
 
 // Params stores libx264 specific encoding parameters.
@@ -41,8 +40,8 @@ func NewParams() (Params, error) {
 }
 
 // Name represents the codec name
-func (p *Params) Name() string {
-	return webrtc.H264
+func (p *Params) Name() codec.Name {
+	return codec.NameH264
 }
 
 // BuildVideoEncoder builds x264 encoder with given params


### PR DESCRIPTION
Depending on webrtc in codec is unnecessary. This PR is to clean up the dependency graph and make it more centralized, having the webrtc dependency in the root package only.