### PR TITLE
Replace Name with RTPCodec in codec builder

### DIFF
--- a/mediadevices_test.go
+++ b/mediadevices_test.go
@@ -161,8 +161,10 @@ type mockParams struct {
 	name string
 }
 
-func (params *mockParams) Name() codec.Name {
-	return codec.Name(params.name)
+func (params *mockParams) RTPCodec() *codec.RTPCodec {
+	rtpCodec := codec.NewRTPH264Codec(90000)
+	rtpCodec.Name = params.name
+	return rtpCodec
 }
 
 func (params *mockParams) BuildVideoEncoder(r video.Reader, p prop.Media) (codec.ReadCloser, error) {

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -6,18 +6,31 @@ import (
 	"github.com/pion/mediadevices/pkg/io/audio"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
+	"github.com/pion/webrtc/v2"
 )
 
-// Name represents codec official name. It's possible to have more than 1 implementations
-// for the same codec name, e.g. openh264 vs x264.
-type Name string
+// RTPCodec wraps webrtc.RTPCodec. RTPCodec might extend webrtc.RTPCodec in the future.
+type RTPCodec webrtc.RTPCodec
 
-const (
-	NameOpus Name = "opus"
-	NameH264 Name = "H264"
-	NameVP8  Name = "VP8"
-	NameVP9  Name = "VP9"
-)
+// NewRTPH264Codec is a helper to create an H264 codec
+func NewRTPH264Codec(clockrate uint32) *RTPCodec {
+	return (*RTPCodec)(webrtc.NewRTPH264Codec(webrtc.DefaultPayloadTypeH264, clockrate))
+}
+
+// NewRTPVP8Codec is a helper to create an VP8 codec
+func NewRTPVP8Codec(clockrate uint32) *RTPCodec {
+	return (*RTPCodec)(webrtc.NewRTPVP8Codec(webrtc.DefaultPayloadTypeVP8, clockrate))
+}
+
+// NewRTPVP9Codec is a helper to create an VP9 codec
+func NewRTPVP9Codec(clockrate uint32) *RTPCodec {
+	return (*RTPCodec)(webrtc.NewRTPVP9Codec(webrtc.DefaultPayloadTypeVP9, clockrate))
+}
+
+// NewRTPOpusCodec is a helper to create an Opus codec
+func NewRTPOpusCodec(clockrate uint32) *RTPCodec {
+	return (*RTPCodec)(webrtc.NewRTPOpusCodec(webrtc.DefaultPayloadTypeOpus, clockrate))
+}
 
 // AudioEncoderBuilder is the interface that wraps basic operations that are
 // necessary to build the audio encoder.
@@ -25,8 +38,8 @@ const (
 // This interface is for codec implementors to provide codec specific params,
 // but still giving generality for the users.
 type AudioEncoderBuilder interface {
-	// Name represents the codec name
-	Name() Name
+	// RTPCodec represents the codec metadata
+	RTPCodec() *RTPCodec
 	// BuildAudioEncoder builds audio encoder by given media params and audio input
 	BuildAudioEncoder(r audio.Reader, p prop.Media) (ReadCloser, error)
 }
@@ -37,8 +50,8 @@ type AudioEncoderBuilder interface {
 // This interface is for codec implementors to provide codec specific params,
 // but still giving generality for the users.
 type VideoEncoderBuilder interface {
-	// Name represents the codec name
-	Name() Name
+	// RTPCodec represents the codec metadata
+	RTPCodec() *RTPCodec
 	// BuildVideoEncoder builds video encoder by given media params and video input
 	BuildVideoEncoder(r video.Reader, p prop.Media) (ReadCloser, error)
 }

--- a/pkg/codec/openh264/params.go
+++ b/pkg/codec/openh264/params.go
@@ -20,9 +20,9 @@ func NewParams() (Params, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *Params) Name() codec.Name {
-	return codec.NameH264
+// RTPCodec represents the codec metadata
+func (p *Params) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPH264Codec(90000)
 }
 
 // BuildVideoEncoder builds openh264 encoder with given params

--- a/pkg/codec/opus/params.go
+++ b/pkg/codec/opus/params.go
@@ -19,9 +19,9 @@ func NewParams() (Params, error) {
 	return Params{}, nil
 }
 
-// Name represents the codec name
-func (p *Params) Name() codec.Name {
-	return codec.NameOpus
+// RTPCodec represents the codec metadata
+func (p *Params) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPOpusCodec(48000)
 }
 
 // BuildAudioEncoder builds opus encoder with given params

--- a/pkg/codec/vaapi/params.go
+++ b/pkg/codec/vaapi/params.go
@@ -43,9 +43,9 @@ func NewVP8Params() (ParamsVP8, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *ParamsVP8) Name() codec.Name {
-	return codec.NameVP8
+// RTPCodec represents the codec metadata
+func (p *ParamsVP8) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPVP8Codec(90000)
 }
 
 // BuildVideoEncoder builds VP8 encoder with given params
@@ -112,9 +112,9 @@ func NewVP9Params() (ParamsVP9, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *ParamsVP9) Name() codec.Name {
-	return codec.NameVP9
+// RTPCodec represents the codec metadata
+func (p *ParamsVP9) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPVP9Codec(90000)
 }
 
 // BuildVideoEncoder builds VP9 encoder with given params

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -94,9 +94,9 @@ func NewVP8Params() (VP8Params, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *VP8Params) Name() codec.Name {
-	return codec.NameVP8
+// RTPCodec represents the codec metadata
+func (p *VP8Params) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPVP8Codec(90000)
 }
 
 // BuildVideoEncoder builds VP8 encoder with given params
@@ -121,9 +121,9 @@ func NewVP9Params() (VP9Params, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *VP9Params) Name() codec.Name {
-	return codec.NameVP9
+// RTPCodec represents the codec metadata
+func (p *VP9Params) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPVP9Codec(90000)
 }
 
 // BuildVideoEncoder builds VP9 encoder with given params

--- a/pkg/codec/x264/params.go
+++ b/pkg/codec/x264/params.go
@@ -39,9 +39,9 @@ func NewParams() (Params, error) {
 	}, nil
 }
 
-// Name represents the codec name
-func (p *Params) Name() codec.Name {
-	return codec.NameH264
+// RTPCodec represents the codec metadata
+func (p *Params) RTPCodec() *codec.RTPCodec {
+	return codec.NewRTPH264Codec(90000)
 }
 
 // BuildVideoEncoder builds x264 encoder with given params

--- a/track.go
+++ b/track.go
@@ -12,15 +12,6 @@ import (
 	"github.com/pion/webrtc/v2/pkg/media"
 )
 
-var (
-	webrtcCodecMapper = map[codec.Name]string{
-		codec.NameH264: webrtc.H264,
-		codec.NameVP8:  webrtc.VP8,
-		codec.NameVP9:  webrtc.VP9,
-		codec.NameOpus: webrtc.Opus,
-	}
-)
-
 // Tracker is an interface that represent MediaStreamTrack
 // Reference: https://w3c.github.io/mediacapture-main/#mediastreamtrack
 type Tracker interface {
@@ -216,14 +207,7 @@ func newVideoEncoderBuilders(vr driver.VideoRecorder, constraints MediaTrackCons
 
 	encoderBuilders := make([]encoderBuilder, len(constraints.VideoEncoderBuilders))
 	for i, b := range constraints.VideoEncoderBuilders {
-		// If the codec name is not in the supported mapping, fallback to as is
-		codecName := b.Name()
-		mappedName, ok := webrtcCodecMapper[codecName]
-		if ok {
-			encoderBuilders[i].name = mappedName
-		} else {
-			encoderBuilders[i].name = string(codecName)
-		}
+		encoderBuilders[i].name = b.RTPCodec().Name
 		encoderBuilders[i].build = func() (codec.ReadCloser, error) {
 			return b.BuildVideoEncoder(r, constraints.selectedMedia)
 		}
@@ -245,14 +229,7 @@ func newAudioEncoderBuilders(ar driver.AudioRecorder, constraints MediaTrackCons
 
 	encoderBuilders := make([]encoderBuilder, len(constraints.AudioEncoderBuilders))
 	for i, b := range constraints.AudioEncoderBuilders {
-		// If the codec name is not in the supported mapping, fallback to as is
-		codecName := b.Name()
-		mappedName, ok := webrtcCodecMapper[codecName]
-		if ok {
-			encoderBuilders[i].name = mappedName
-		} else {
-			encoderBuilders[i].name = string(codecName)
-		}
+		encoderBuilders[i].name = b.RTPCodec().Name
 		encoderBuilders[i].build = func() (codec.ReadCloser, error) {
 			return b.BuildAudioEncoder(r, constraints.selectedMedia)
 		}


### PR DESCRIPTION
Allowing users to implement RTPCodec will give users freedom to have a custom encoder with custom RTP payload. This is another incremental update toward the new design.

Use case:

```go
package main

import (
	"github.com/pion/mediadevices"
	"github.com/pion/mediadevices/pkg/codec/openh264"
	"github.com/pion/mediadevices/pkg/codec/x264"
	"github.com/pion/mediadevices/pkg/prop"

	// Note: If you don't have a camera or microphone or your adapters are not supported,
	//       you can always swap your adapters with our dummy adapters below.
	// _ "github.com/pion/mediadevices/pkg/driver/videotest"
	_ "github.com/pion/mediadevices/pkg/driver/camera" // This is required to register camera adapter
)

func main() {
	var setting webrtc.SettingEngine

	x264Params, _ := x264.NewParams()
	openh264Params, _ := openh264.NewParams()
	rtpTracker, _ := mediadevices.NewRTPTracker(x264Params, openh264Params) 
	rtpTracker.PopulateSetting(&setting) // <--- We can easily register custom RTPCodec

	// User can still modify setting to their needs here

	api := webrtc.NewAPI(webrtc.WithSettingEngine(&setting))

	// Assume that we have configured the api and have proper config
	pc, _ := api.NewPeerConnection(peerConnectionConfig)

	mediaStream, _ := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
		Video: func(constraint *mediadevices.MediaTrackConstraints) {
			constraint.Width = prop.Int(600)
			constraint.Height = prop.Int(400)
		},
	})

	for _, mediaTrack := range mediaStream.GetTracks() {
		// rtpTracker.Track will create LocalRTPTrack, which later can be used for pulling video/audio frames.
		pc.AddTransceiverFromTrack(rtpTracker.Track(mediaTrack),
			webrtc.RtpTransceiverInit{
				Direction: webrtc.RTPTransceiverDirectionSendonly,
			},
		)
	}

	// peerconnection should negotiate with the other peer
	// peerconnection should set the negotiated codec with LocalRTPTrack.setParameters()

	// mediadevices then will set the codec and attach the encoder to the pipeline. PeerConnection now can start
	// pulling encoded frames from mediadevices.
}
```

Note: I had to bring back webrtc dependency to codec because I don't know any better place to have the mapping from codec name to RTPCodec.