### PR TITLE
Remove buffer in linux camera

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -83,6 +83,8 @@ func (c *camera) Open() error {
 		return err
 	}
 
+	// Late frames should be discarded. Buffering should be handled in higher level.
+	cam.SetBufferCount(1)
 	c.cam = cam
 	return nil
 }


### PR DESCRIPTION
Speed up camera latency. On raspberry pi 3, the latency goes down from 3-5 seconds to <1 second with this change.