### PR TITLE
Tolerate video frame rate variation in properties detector

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -14,7 +14,7 @@ func detectCurrentVideoProp(broadcaster *video.Broadcaster) (prop.Media, error) 
 	// buffered frame or a new frame from the source. This also implies that no frame will be lost
 	// in any case.
 	metaReader := broadcaster.NewReader(false)
-	metaReader = video.DetectChanges(0, func(p prop.Media) { currentProp = p })(metaReader)
+	metaReader = video.DetectChanges(0, 0, func(p prop.Media) { currentProp = p })(metaReader)
 	_, _, err := metaReader.Read()
 
 	return currentProp, err

--- a/pkg/io/video/detect_test.go
+++ b/pkg/io/video/detect_test.go
@@ -3,7 +3,6 @@ package video
 import (
 	"fmt"
 	"image"
-	"math/rand"
 	"runtime"
 	"testing"
 	"time"
@@ -77,8 +76,6 @@ func TestDetectChanges(t *testing.T) {
 
 	SlowDownAfterThrottle := func(rate float32, factor float64, after time.Duration) TransformFunc {
 		return func(r Reader) Reader {
-			// fix seed value for random operations
-			rand.Seed(42)
 			sleep := float64(time.Second) / float64(rate)
 			start := time.Now()
 			f := 1.0

--- a/pkg/io/video/detect_test.go
+++ b/pkg/io/video/detect_test.go
@@ -28,7 +28,7 @@ func BenchmarkDetectChanges(b *testing.B) {
 		src := src
 		b.Run(fmt.Sprintf("WithDetectChanges%d", n), func(b *testing.B) {
 			for i := 0; i < n; i++ {
-				src = DetectChanges(time.Microsecond, func(p prop.Media) {})(src)
+				src = DetectChanges(time.Microsecond, 0, func(p prop.Media) {})(src)
 			}
 
 			for i := 0; i < b.N; i++ {
@@ -81,7 +81,7 @@ func TestDetectChanges(t *testing.T) {
 		expected.Width = 1920
 		expected.Height = 1080
 		src, _ := buildSource(expected)
-		src = DetectChanges(time.Second, func(p prop.Media) {
+		src = DetectChanges(time.Second, 0, func(p prop.Media) {
 			actual = p
 			detectBeforeFirstFrame = true
 		})(src)
@@ -104,7 +104,7 @@ func TestDetectChanges(t *testing.T) {
 		expected.Width = 1920
 		expected.Height = 1080
 		src, update := buildSource(expected)
-		src = DetectChanges(time.Second, func(p prop.Media) {
+		src = DetectChanges(time.Second, 0, func(p prop.Media) {
 			actual = p
 		})(src)
 
@@ -137,7 +137,7 @@ func TestDetectChanges(t *testing.T) {
 		expected.FrameRate = 30
 		src, _ := buildSource(expected)
 		src = Throttle(expected.FrameRate)(src)
-		src = DetectChanges(time.Second*5, func(p prop.Media) {
+		src = DetectChanges(time.Second*5, 0, func(p prop.Media) {
 			actual = p
 			count++
 		})(src)


### PR DESCRIPTION
#### Description
This PR adds an argument to the `video.DetectChanges` function to allow for frame rate variations as long as they are within the specified margin.  

#### Reference issue
Fixes #...
It addresses this comment: https://github.com/pion/mediadevices/blob/5d5001d0b43f1687741122ee66dd22b0542c6ebe/pkg/io/video/detect.go#L43