### PR TITLE
Add license check to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,3 +81,17 @@ jobs:
         run: go test . pkg/... -v
         env:
           CGO_ENABLED: 0
+  check-licenses:
+    runs-on: ubuntu-latest
+    name: Check Licenses
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - name: Installing go-licenses
+        run: go get github.com/google/go-licenses
+      - name: Checking licenses
+        run: go-licenses check ./...


### PR DESCRIPTION
Add an automated license check to CI. Since we're using various third-party libraries, this automated check should help us in the long run.

Suggested by @at-wat: https://github.com/pion/mediadevices/pull/264#pullrequestreview-550878544