### PR TITLE
Add example compilation test to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,22 +30,10 @@ jobs:
             libva-dev \
             libvpx-dev \
             libx264-dev
-      - name: go vet
-        run: go vet $(go list ./... | grep -v mmal)
-      - name: go build
-        run: go build $(go list ./... | grep -v mmal)
-      - name: go build without CGO
-        run: go build . pkg/...
-        env:
-          CGO_ENABLED: 0
-      - name: go test
-        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v mmal)
-      - uses: codecov/codecov-action@v1
+      - name: Run Test Suite
+        run: make test
+      - uses: codecov/codecov-action@v1	
         if: matrix.go == '1.15'
-      - name: go test without CGO
-        run: go test . pkg/... -v
-        env:
-          CGO_ENABLED: 0
   build-darwin:
     runs-on: macos-latest
     strategy:
@@ -67,20 +55,8 @@ jobs:
             opus \
             libvpx \
             x264
-      - name: go vet
-        run: go vet $(go list ./... | grep -v mmal)
-      - name: go build
-        run: go build $(go list ./... | grep -v mmal)
-      - name: go build without CGO
-        run: go build . pkg/...
-        env:
-          CGO_ENABLED: 0
-      - name: go test
-        run: go test -v -race $(go list ./... | grep -v mmal)
-      - name: go test without CGO
-        run: go test . pkg/... -v
-        env:
-          CGO_ENABLED: 0
+      - name: Run Test Suite
+        run: make test
   check-licenses:
     runs-on: ubuntu-latest
     name: Check Licenses

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 scripts/cross
+coverage.txt

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,8 @@
+examples := $(shell find * -maxdepth 0 -type d)
+examples := $(filter-out internal,$(examples))
+
+.PHONY: all $(examples)
+all: $(examples)
+
+$(examples):
+	cd $@ && go build

--- a/pkg/io/video/convert_cgo.go
+++ b/pkg/io/video/convert_cgo.go
@@ -7,6 +7,7 @@ import (
 )
 
 // #include "convert_cgo.h"
+// #cgo CFLAGS: -std=c11
 import "C"
 
 // CGO version of the functions will be selected at runtime.


### PR DESCRIPTION
Changes:
  * Make codec build command now is prefixed with "build"
  * A new "test" command to make
  * Add a Makefile for examples

