### PR TITLE
Switch default frame format to I420

### DIFF
--- a/examples/archive/main.go
+++ b/examples/archive/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	mediaStream, err := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.FrameFormat = prop.FrameFormat(frame.FormatYUY2)
+			c.FrameFormat = prop.FrameFormat(frame.FormatI420)
 			c.Width = prop.Int(640)
 			c.Height = prop.Int(480)
 		},

--- a/examples/facedetection/main.go
+++ b/examples/facedetection/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	mediaStream, err := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.FrameFormat = prop.FrameFormatExact(frame.FormatUYVY)
+			c.FrameFormat = prop.FrameFormatExact(frame.FormatI420)
 			c.Width = prop.Int(640)
 			c.Height = prop.Int(480)
 		},

--- a/examples/rtp/main.go
+++ b/examples/rtp/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	mediaStream, err := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.FrameFormat = prop.FrameFormat(frame.FormatYUY2)
+			c.FrameFormat = prop.FrameFormat(frame.FormatI420)
 			c.Width = prop.Int(640)
 			c.Height = prop.Int(480)
 		},

--- a/examples/webrtc/main.go
+++ b/examples/webrtc/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	s, err := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.FrameFormat = prop.FrameFormat(frame.FormatYUY2)
+			c.FrameFormat = prop.FrameFormat(frame.FormatI420)
 			c.Width = prop.Int(640)
 			c.Height = prop.Int(480)
 		},


### PR DESCRIPTION
I420 format is a common format that's required by encoders. Therefore, the video pipeline is significantly faster than other formats since there's no format conversion.
