### PR TITLE
Fix VPX_CODEC_INVALID_PARAM on resolution change

### DIFF
--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -240,9 +240,15 @@ func (e *encoder) Read(p []byte) (int, error) {
 
 	if e.cfg.g_w != C.uint(width) || e.cfg.g_h != C.uint(height) {
 		e.cfg.g_w, e.cfg.g_h = C.uint(width), C.uint(height)
-		if ec := C.vpx_codec_enc_config_set(e.codec, e.cfg); ec != C.VPX_CODEC_OK {
-			return 0, fmt.Errorf("vpx_codec_enc_config_set failed (%d)", ec)
+
+		newCodec := C.newCtx()
+		if ec := C.vpx_codec_enc_init_ver(
+			newCodec, e.codec.iface, e.cfg, 0, C.VPX_ENCODER_ABI_VERSION,
+		); ec != 0 {
+			return 0, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
 		}
+		e.codec = newCodec
+
 		e.raw.w, e.raw.h = C.uint(width), C.uint(height)
 		e.raw.r_w, e.raw.r_h = C.uint(width), C.uint(height)
 		e.raw.d_w, e.raw.d_h = C.uint(width), C.uint(height)


### PR DESCRIPTION
#### Description
The following error occurs when scaling up the video frames using transform function such as `video.Scale(width, height, video.ScalerFastBoxSampling)` with `width` or `height` greater than the original frame dimension:
```
vpx_codec_enc_config_set failed (8)
```

Although this block seems to work fine when scaling down the frame, it does not seem to be enough in this case:
```
if ec := C.vpx_codec_enc_config_set(e.codec, e.cfg); ec != C.VPX_CODEC_OK {
 	return 0, fmt.Errorf("vpx_codec_enc_config_set failed (%d)", ec)
}
```

Creating an initializing a new codec object seem necessary.