### PR TITLE
Add AVBindFrameFormatYUY2 mapping in AVFoundationBind

### DIFF
--- a/examples/facedetection/main.go
+++ b/examples/facedetection/main.go
@@ -8,8 +8,8 @@ import (
 
 	pigo "github.com/esimov/pigo/core"
 	"github.com/pion/mediadevices"
-	_ "github.com/pion/mediadevices/pkg/driver/camera" // This is required to register camera adapter
 	"github.com/pion/mediadevices/pkg/frame"
+	_ "github.com/pion/mediadevices/pkg/driver/camera" // This is required to register camera adapter
 	"github.com/pion/mediadevices/pkg/prop"
 )
 
@@ -77,7 +77,7 @@ func main() {
 
 	mediaStream, err := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
 		Video: func(c *mediadevices.MediaTrackConstraints) {
-			c.FrameFormat = prop.FrameFormatExact(frame.FormatI420)
+			c.FrameFormat = prop.FrameFormatOneOf{frame.FormatI420, frame.FormatYUY2}
 			c.Width = prop.Int(640)
 			c.Height = prop.Int(480)
 		},
@@ -97,7 +97,7 @@ func main() {
 		frame, release, err := videoReader.Read()
 		must(err)
 
-		// Since we asked the frame format to be exactly YUY2 in GetUserMedia, we can guarantee that it must be YCbCr
+		// Since we asked the frame format to be exactly I420/YUY2 in GetUserMedia, we can guarantee that it must be YCbCr
 		if detectFace(frame.(*image.YCbCr)) {
 			log.Println("Detect a face")
 		}

--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
@@ -140,6 +140,9 @@ STATUS frameFormatToFourCC(AVBindFrameFormat format, FourCharCode *pFourCC) {
         case AVBindFrameFormatUYVY:
             *pFourCC = kCVPixelFormatType_422YpCbCr8;
             break;
+        case AVBindFrameFormatYUY2:
+            *pFourCC = kCVPixelFormatType_422YpCbCr8_yuvs;
+            break;
         // TODO: Add the rest of frame formats
         default:
             retStatus = STATUS_UNSUPPORTED_FRAME_FORMAT;
@@ -150,12 +153,15 @@ STATUS frameFormatToFourCC(AVBindFrameFormat format, FourCharCode *pFourCC) {
 STATUS frameFormatFromFourCC(FourCharCode fourCC, AVBindFrameFormat *pFormat) {
     STATUS retStatus = STATUS_OK;
     switch (fourCC) {
-         case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
-             *pFormat = AVBindFrameFormatNV21;
-             break;
-         case kCVPixelFormatType_422YpCbCr8:
-             *pFormat = AVBindFrameFormatUYVY;
-             break;
+        case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+            *pFormat = AVBindFrameFormatNV21;
+            break;
+        case kCVPixelFormatType_422YpCbCr8:
+            *pFormat = AVBindFrameFormatUYVY;
+            break;
+        case kCVPixelFormatType_422YpCbCr8_yuvs:
+            *pFormat = AVBindFrameFormatYUY2;
+            break;
          // TODO: Add the rest of frame formats
          default:
              retStatus = STATUS_UNSUPPORTED_FRAME_FORMAT;


### PR DESCRIPTION
#### Description
Attempt to fix the MacOS integrated camera pixel format issues.

The integrated camera on my 2018 Macbook Pro supports the following pixel formats:
```
[avfoundation @ 0x7f8e3a808200] Supported pixel formats:
[avfoundation @ 0x7f8e3a808200]   uyvy422
[avfoundation @ 0x7f8e3a808200]   yuyv422
[avfoundation @ 0x7f8e3a808200]   nv12
[avfoundation @ 0x7f8e3a808200]   0rgb
[avfoundation @ 0x7f8e3a808200]   bgr0
```

I was only able to find the correct mapping for the YUY2 pixel format and it fixed my issue. If anyone knows the other mappings I can update this PR.

#### Reference issue
Fixes #287
