### PR TITLE
Add formats and logging to AVFoundation backend

### DIFF
--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
@@ -45,6 +45,7 @@ typedef enum AVBindMediaType {
 typedef enum AVBindFrameFormat {
     AVBindFrameFormatI420,
     AVBindFrameFormatNV21,
+    AVBindFrameFormatNV12,
     AVBindFrameFormatYUY2,
     AVBindFrameFormatUYVY,
 } AVBindFrameFormat;

--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
@@ -133,9 +133,14 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 
 STATUS frameFormatToFourCC(AVBindFrameFormat format, FourCharCode *pFourCC) {
     STATUS retStatus = STATUS_OK;
+    // Useful mapping reference from ffmpeg:
+    // https://github.com/FFmpeg/FFmpeg/blob/c810a9502cebe32e1dd08ee3d0d17053dde44aa9/libavdevice/avfoundation.m#L53-L80
     switch (format) {
         case AVBindFrameFormatNV21:
             *pFourCC = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+            break;
+        case AVBindFrameFormatNV12:
+            *pFourCC = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
             break;
         case AVBindFrameFormatUYVY:
             *pFourCC = kCVPixelFormatType_422YpCbCr8;
@@ -155,6 +160,9 @@ STATUS frameFormatFromFourCC(FourCharCode fourCC, AVBindFrameFormat *pFormat) {
     switch (fourCC) {
         case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
             *pFormat = AVBindFrameFormatNV21;
+            break;
+        case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+            *pFormat = AVBindFrameFormatNV12;
             break;
         case kCVPixelFormatType_422YpCbCr8:
             *pFormat = AVBindFrameFormatUYVY;

--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
@@ -316,6 +316,16 @@ cleanup:
     return retStatus;
 }
 
+static NSString* FourCCString(FourCharCode code) {
+    NSString *result = [NSString stringWithFormat:@"%c%c%c%c",
+                        (code >> 24) & 0xff,
+                        (code >> 16) & 0xff,
+                        (code >> 8) & 0xff,
+                        code & 0xff];
+    NSCharacterSet *characterSet = [NSCharacterSet whitespaceCharacterSet];
+    return [result stringByTrimmingCharactersInSet:characterSet];
+}
+
 STATUS AVBindSessionProperties(PAVBindSession pSession, PAVBindMediaProperty *ppProperties, int *pLen) {
     STATUS retStatus = STATUS_OK;
     NSAutoreleasePool *refPool = [[NSAutoreleasePool alloc] init];
@@ -333,12 +343,14 @@ STATUS AVBindSessionProperties(PAVBindSession pSession, PAVBindMediaProperty *pp
     for (AVCaptureDeviceFormat *refFormat in refDevice.formats) {
         // TODO: Probably gives a warn to the user
         if (len >= MAX_PROPERTIES) {
+            NSLog(@"[WARNING] skipping the rest of properties due to MAX_PROPERTIES");
             break;
         }
         
         if ([refFormat.mediaType isEqual:AVMediaTypeVideo]) {
             fourCC = CMFormatDescriptionGetMediaSubType(refFormat.formatDescription);
             if (frameFormatFromFourCC(fourCC, &pProperty->frameFormat) != STATUS_OK) {
+                NSLog(@"[WARNING] skipping %@ %dx%d since it's not supported", FourCCString(fourCC), videoDimensions.width, videoDimensions.height);
                 continue;
             }
             

--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -40,6 +40,8 @@ func frameFormatToAVBind(f frame.Format) (C.AVBindFrameFormat, bool) {
 		return C.AVBindFrameFormatI420, true
 	case frame.FormatNV21:
 		return C.AVBindFrameFormatNV21, true
+	case frame.FormatNV12:
+		return C.AVBindFrameFormatNV12, true
 	case frame.FormatYUY2:
 		return C.AVBindFrameFormatYUY2, true
 	case frame.FormatUYVY:
@@ -55,6 +57,8 @@ func frameFormatFromAVBind(f C.AVBindFrameFormat) (frame.Format, bool) {
 		return frame.FormatI420, true
 	case C.AVBindFrameFormatNV21:
 		return frame.FormatNV21, true
+	case C.AVBindFrameFormatNV12:
+		return frame.FormatNV12, true
 	case C.AVBindFrameFormatYUY2:
 		return frame.FormatYUY2, true
 	case C.AVBindFrameFormatUYVY:

--- a/pkg/frame/const.go
+++ b/pkg/frame/const.go
@@ -9,6 +9,8 @@ const (
 	FormatI444 Format = "I444"
 	// FormatNV21 https://www.fourcc.org/pixel-format/yuv-nv21/
 	FormatNV21 = "NV21"
+	// FormatNV12 https://www.fourcc.org/pixel-format/yuv-nv12/
+	FormatNV12 = "NV12"
 	// FormatYUY2 https://www.fourcc.org/pixel-format/yuv-yuy2/
 	FormatYUY2 = "YUY2"
 	// FormatUYVY https://www.fourcc.org/pixel-format/yuv-uyvy/

--- a/pkg/frame/yuv.go
+++ b/pkg/frame/yuv.go
@@ -35,8 +35,8 @@ func decodeNV21(frame []byte, width, height int) (image.Image, func(), error) {
 
 	var cb, cr []byte
 	for i := yi; i < ci; i += 2 {
-		cb = append(cb, frame[i])
-		cr = append(cr, frame[i+1])
+		cr = append(cr, frame[i])
+		cb = append(cb, frame[i+1])
 	}
 
 	return &image.YCbCr{

--- a/pkg/frame/yuv.go
+++ b/pkg/frame/yuv.go
@@ -49,3 +49,15 @@ func decodeNV21(frame []byte, width, height int) (image.Image, func(), error) {
 		Rect:           image.Rect(0, 0, width, height),
 	}, func() {}, nil
 }
+
+func decodeNV12(frame []byte, width, height int) (image.Image, func(), error) {
+	img, release, err := decodeNV21(frame, width, height)
+	if err != nil {
+		return img, release, err
+	}
+
+	// The only difference between NV21 and NV12 is the chroma order, so simply swap them
+	yuv := img.(*image.YCbCr)
+	yuv.Cb, yuv.Cr = yuv.Cr, yuv.Cb
+	return yuv, release, err
+}

--- a/pkg/frame/yuv_test.go
+++ b/pkg/frame/yuv_test.go
@@ -65,6 +65,35 @@ func TestDecodeUYVY(t *testing.T) {
 	}
 }
 
+func TestDecodeNV21(t *testing.T) {
+	const (
+		width  = 2
+		height = 2
+	)
+	input := []byte{
+		0x01, 0x03, 0x05, 0x07, // Y
+		// Cr  Cb
+		0x82, 0x84,
+	}
+	expected := &image.YCbCr{
+		Y:              []byte{0x01, 0x03, 0x05, 0x07},
+		YStride:        width,
+		Cb:             []byte{0x84},
+		Cr:             []byte{0x82},
+		CStride:        width / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect:           image.Rect(0, 0, width, height),
+	}
+
+	img, _, err := decodeNV21(input, width, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, img) {
+		t.Errorf("Wrong decode result,\nexpected:\n%+v\ngot:\n%+v", expected, img)
+	}
+}
+
 func BenchmarkDecodeYUY2(b *testing.B) {
 	sizes := []struct {
 		width, height int

--- a/pkg/frame/yuv_test.go
+++ b/pkg/frame/yuv_test.go
@@ -94,6 +94,35 @@ func TestDecodeNV21(t *testing.T) {
 	}
 }
 
+func TestDecodeNV12(t *testing.T) {
+	const (
+		width  = 2
+		height = 2
+	)
+	input := []byte{
+		0x01, 0x03, 0x05, 0x07, // Y
+		// Cb  Cr
+		0x84, 0x82,
+	}
+	expected := &image.YCbCr{
+		Y:              []byte{0x01, 0x03, 0x05, 0x07},
+		YStride:        width,
+		Cb:             []byte{0x84},
+		Cr:             []byte{0x82},
+		CStride:        width / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect:           image.Rect(0, 0, width, height),
+	}
+
+	img, _, err := decodeNV12(input, width, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, img) {
+		t.Errorf("Wrong decode result,\nexpected:\n%+v\ngot:\n%+v", expected, img)
+	}
+}
+
 func BenchmarkDecodeYUY2(b *testing.B) {
 	sizes := []struct {
 		width, height int


### PR DESCRIPTION
Changes:
* Add logging for unincluded raw frame formats
* Add NV12 support for avfoundation
* Fix wrong Cb and Cr order in NV21

Possibly resolves https://github.com/pion/mediadevices/issues/292