### PR TITLE
Return selected codec information in NewEncodedReader and NewEncodedIOReader.

### DIFF
--- a/examples/archive/main.go
+++ b/examples/archive/main.go
@@ -68,7 +68,7 @@ func main() {
 		})
 	}))
 
-	reader, err := videoTrack.NewEncodedIOReader(x264Params.RTPCodec().MimeType)
+	reader, _, err := videoTrack.NewEncodedIOReader(x264Params.RTPCodec().MimeType)
 	must(err)
 	defer reader.Close()
 

--- a/mediastream_test.go
+++ b/mediastream_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/webrtc/v3"
 )
 
@@ -49,12 +50,12 @@ func (track *mockMediaStreamTrack) NewRTPReader(codecName string, ssrc uint32, m
 	return nil, nil
 }
 
-func (track *mockMediaStreamTrack) NewEncodedReader(codecName string) (EncodedReadCloser, error) {
-	return nil, nil
+func (track *mockMediaStreamTrack) NewEncodedReader(codecName string) (EncodedReadCloser, *codec.RTPCodec, error) {
+	return nil, nil, nil
 }
 
-func (track *mockMediaStreamTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, error) {
-	return nil, nil
+func (track *mockMediaStreamTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, *codec.RTPCodec, error) {
+	return nil, nil, nil
 }
 
 func TestMediaStreamFilters(t *testing.T) {

--- a/track.go
+++ b/track.go
@@ -66,9 +66,9 @@ type Track interface {
 	// the encoded data in RTP format with given mtu size.
 	NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error)
 	// NewEncodedReader creates a EncodedReadCloser that reads the encoded data in codecName format
-	NewEncodedReader(codecName string) (EncodedReadCloser, error)
+	NewEncodedReader(codecName string) (EncodedReadCloser, *codec.RTPCodec, error)
 	// NewEncodedReader creates a new Go standard io.ReadCloser that reads the encoded data in codecName format
-	NewEncodedIOReader(codecName string) (io.ReadCloser, error)
+	NewEncodedIOReader(codecName string) (io.ReadCloser, *codec.RTPCodec, error)
 }
 
 type baseTrack struct {
@@ -320,17 +320,17 @@ func (track *VideoTrack) newEncodedReader(codecNames ...string) (EncodedReadClos
 	}, selectedCodec, nil
 }
 
-func (track *VideoTrack) NewEncodedReader(codecName string) (EncodedReadCloser, error) {
-	reader, _, err := track.newEncodedReader(codecName)
-	return reader, err
+func (track *VideoTrack) NewEncodedReader(codecName string) (EncodedReadCloser, *codec.RTPCodec, error) {
+	reader, codec, err := track.newEncodedReader(codecName)
+	return reader, codec, err
 }
 
-func (track *VideoTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, error) {
-	encodedReader, _, err := track.newEncodedReader(codecName)
+func (track *VideoTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, *codec.RTPCodec, error) {
+	encodedReader, selectedCodec, err := track.newEncodedReader(codecName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return newEncodedIOReadCloserImpl(encodedReader), nil
+	return newEncodedIOReadCloserImpl(encodedReader), selectedCodec, nil
 }
 
 func (track *VideoTrack) NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error) {
@@ -440,17 +440,17 @@ func (track *AudioTrack) newEncodedReader(codecNames ...string) (EncodedReadClos
 	}, selectedCodec, nil
 }
 
-func (track *AudioTrack) NewEncodedReader(codecName string) (EncodedReadCloser, error) {
-	reader, _, err := track.newEncodedReader(codecName)
-	return reader, err
+func (track *AudioTrack) NewEncodedReader(codecName string) (EncodedReadCloser, *codec.RTPCodec, error) {
+	reader, codec, err := track.newEncodedReader(codecName)
+	return reader, codec, err
 }
 
-func (track *AudioTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, error) {
-	encodedReader, _, err := track.newEncodedReader(codecName)
+func (track *AudioTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, *codec.RTPCodec, error) {
+	encodedReader, selectedCodec, err := track.newEncodedReader(codecName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return newEncodedIOReadCloserImpl(encodedReader), nil
+	return newEncodedIOReadCloserImpl(encodedReader), selectedCodec, nil
 }
 
 func (track *AudioTrack) NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error) {


### PR DESCRIPTION
#### Description

In this PR, a pointer to the selected codec is added to the results returned by `NewEncodedReader` and `NewEncodedIOReader`. At the moment only `newEncodedReader` returns this information but it is not accessible outside of the `track` class. The selected codec information might useful if ones wants to use a custom RTP `Packetizer`. This is also the reason why it needs to
return `rtp.Codec` instead of `webrtc.RTPCodecParameters`: `rtp.NewPacketizer` needs a `rtp.Payloader`.
