### PR TITLE
Allow double close of codecs

### DIFF
--- a/pkg/codec/internal/codectest/codectest.go
+++ b/pkg/codec/internal/codectest/codectest.go
@@ -1,0 +1,55 @@
+// Package codectest provides shared test for codec implementations.
+package codectest
+
+import (
+	"image"
+	"io"
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/codec"
+	"github.com/pion/mediadevices/pkg/io/audio"
+	"github.com/pion/mediadevices/pkg/io/video"
+	"github.com/pion/mediadevices/pkg/prop"
+	"github.com/pion/mediadevices/pkg/wave"
+)
+
+func assertNoPanic(t *testing.T, fn func() error, msg string) error {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("panic: %v: %s", r, msg)
+		}
+	}()
+	return fn()
+}
+
+func AudioEncoderCloseTwiceTest(t *testing.T, c codec.AudioEncoderBuilder, p prop.Media) {
+	enc, err := c.BuildAudioEncoder(audio.ReaderFunc(func() (wave.Audio, func(), error) {
+		return nil, nil, io.EOF
+	}), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assertNoPanic(t, enc.Close, "on first Close()"); err != nil {
+		t.Fatal(err)
+	}
+	if err := assertNoPanic(t, enc.Close, "on second Close()"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func VideoEncoderCloseTwiceTest(t *testing.T, c codec.VideoEncoderBuilder, p prop.Media) {
+	enc, err := c.BuildVideoEncoder(video.ReaderFunc(func() (image.Image, func(), error) {
+		return nil, nil, io.EOF
+	}), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assertNoPanic(t, enc.Close, "on first Close()"); err != nil {
+		t.Fatal(err)
+	}
+	if err := assertNoPanic(t, enc.Close, "on second Close()"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/codec/mmal/mmal_test.go
+++ b/pkg/codec/mmal/mmal_test.go
@@ -1,0 +1,26 @@
+package mmal
+
+import (
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("CloseTwice", func(t *testing.T) {
+		p, err := NewParams()
+		if err != nil {
+			t.Fatal(err)
+		}
+		codectest.VideoEncoderCloseTwiceTest(t, &p, prop.Media{
+			Video: prop.Video{
+				Width:       640,
+				Height:      480,
+				FrameRate:   30,
+				FrameFormat: frame.FormatI420,
+			},
+		})
+	})
+}

--- a/pkg/codec/openh264/openh264.go
+++ b/pkg/codec/openh264/openh264.go
@@ -92,6 +92,10 @@ func (e *encoder) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return nil
+	}
+
 	e.closed = true
 
 	var rv C.int

--- a/pkg/codec/openh264/openh264_test.go
+++ b/pkg/codec/openh264/openh264_test.go
@@ -1,0 +1,26 @@
+package openh264
+
+import (
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("CloseTwice", func(t *testing.T) {
+		p, err := NewParams()
+		if err != nil {
+			t.Fatal(err)
+		}
+		codectest.VideoEncoderCloseTwiceTest(t, &p, prop.Media{
+			Video: prop.Video{
+				Width:       640,
+				Height:      480,
+				FrameRate:   30,
+				FrameFormat: frame.FormatI420,
+			},
+		})
+	})
+}

--- a/pkg/codec/opus/opus.go
+++ b/pkg/codec/opus/opus.go
@@ -126,6 +126,9 @@ func (e *encoder) ForceKeyFrame() error {
 }
 
 func (e *encoder) Close() error {
+	if e.engine == nil {
+		return nil
+	}
 	C.opus_encoder_destroy(e.engine)
 	e.engine = nil
 	return nil

--- a/pkg/codec/opus/opus_test.go
+++ b/pkg/codec/opus/opus_test.go
@@ -1,0 +1,22 @@
+package opus
+
+import (
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
+	"github.com/pion/mediadevices/pkg/prop"
+	"testing"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("CloseTwice", func(t *testing.T) {
+		p, err := NewParams()
+		if err != nil {
+			t.Fatal(err)
+		}
+		codectest.AudioEncoderCloseTwiceTest(t, &p, prop.Media{
+			Audio: prop.Audio{
+				SampleRate:   48000,
+				ChannelCount: 2,
+			},
+		})
+	})
+}

--- a/pkg/codec/vaapi/vaapi_test.go
+++ b/pkg/codec/vaapi/vaapi_test.go
@@ -1,0 +1,47 @@
+package vaapi
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/codec"
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+func TestEncoder(t *testing.T) {
+	if _, err := os.Stat("/dev/dri/card0"); errors.Is(err, os.ErrNotExist) {
+		t.Skip("/dev/dri/card0 not found")
+	}
+
+	for name, factory := range map[string]func() (codec.VideoEncoderBuilder, error){
+		"VP8": func() (codec.VideoEncoderBuilder, error) {
+			p, err := NewVP8Params()
+			return &p, err
+		},
+		"VP9": func() (codec.VideoEncoderBuilder, error) {
+			p, err := NewVP9Params()
+			return &p, err
+		},
+	} {
+		factory := factory
+		t.Run(name, func(t *testing.T) {
+			t.Run("CloseTwice", func(t *testing.T) {
+				p, err := factory()
+				if err != nil {
+					t.Fatal(err)
+				}
+				codectest.VideoEncoderCloseTwiceTest(t, p, prop.Media{
+					Video: prop.Video{
+						Width:       640,
+						Height:      480,
+						FrameRate:   30,
+						FrameFormat: frame.FormatI420,
+					},
+				})
+			})
+		})
+	}
+}

--- a/pkg/codec/vaapi/vp8.go
+++ b/pkg/codec/vaapi/vp8.go
@@ -1,3 +1,4 @@
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build dragonfly freebsd linux netbsd openbsd solaris
 
 package vaapi
@@ -551,6 +552,10 @@ func (e *encoderVP8) ForceKeyFrame() error {
 func (e *encoderVP8) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	if e.closed {
+		return nil
+	}
 
 	C.vaDestroySurfaces(e.display, &e.surfs[0], C.int(len(e.surfs)))
 	C.vaDestroyContext(e.display, e.ctxID)

--- a/pkg/codec/vaapi/vp9.go
+++ b/pkg/codec/vaapi/vp9.go
@@ -1,3 +1,4 @@
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build dragonfly freebsd linux netbsd openbsd solaris
 
 package vaapi
@@ -486,6 +487,10 @@ func (e *encoderVP9) ForceKeyFrame() error {
 func (e *encoderVP9) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	if e.closed {
+		return nil
+	}
 
 	C.vaDestroySurfaces(e.display, &e.surfs[0], C.int(len(e.surfs)))
 	C.vaDestroyContext(e.display, e.ctxID)

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -310,6 +310,10 @@ func (e *encoder) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	if e.closed {
+		return nil
+	}
+
 	e.closed = true
 
 	C.free(unsafe.Pointer(e.raw))

--- a/pkg/codec/vpx/vpx_test.go
+++ b/pkg/codec/vpx/vpx_test.go
@@ -7,10 +7,42 @@ import (
 	"testing"
 
 	"github.com/pion/mediadevices/pkg/codec"
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
 	"github.com/pion/mediadevices/pkg/frame"
 	"github.com/pion/mediadevices/pkg/io/video"
 	"github.com/pion/mediadevices/pkg/prop"
 )
+
+func TestEncoder(t *testing.T) {
+	for name, factory := range map[string]func() (codec.VideoEncoderBuilder, error){
+		"VP8": func() (codec.VideoEncoderBuilder, error) {
+			p, err := NewVP8Params()
+			return &p, err
+		},
+		"VP9": func() (codec.VideoEncoderBuilder, error) {
+			p, err := NewVP9Params()
+			return &p, err
+		},
+	} {
+		factory := factory
+		t.Run(name, func(t *testing.T) {
+			t.Run("CloseTwice", func(t *testing.T) {
+				p, err := factory()
+				if err != nil {
+					t.Fatal(err)
+				}
+				codectest.VideoEncoderCloseTwiceTest(t, p, prop.Media{
+					Video: prop.Video{
+						Width:       640,
+						Height:      480,
+						FrameRate:   30,
+						FrameFormat: frame.FormatI420,
+					},
+				})
+			})
+		})
+	}
+}
 
 func TestImageSizeChange(t *testing.T) {
 	for name, factory := range map[string]func() (codec.VideoEncoderBuilder, error){

--- a/pkg/codec/x264/x264_test.go
+++ b/pkg/codec/x264/x264_test.go
@@ -1,0 +1,27 @@
+package x264
+
+import (
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/codec/internal/codectest"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("CloseTwice", func(t *testing.T) {
+		p, err := NewParams()
+		if err != nil {
+			t.Fatal(err)
+		}
+		p.BitRate = 200000
+		codectest.VideoEncoderCloseTwiceTest(t, &p, prop.Media{
+			Video: prop.Video{
+				Width:       640,
+				Height:      480,
+				FrameRate:   30,
+				FrameFormat: frame.FormatI420,
+			},
+		})
+	})
+}


### PR DESCRIPTION
`Video/AudioTrack.NewRTPReader()` internally closes encoder on error.
It caused double free if user closes reader after error.