### PR TITLE
Release AVFoundation ReadCloser on camera close

### DIFF
--- a/pkg/driver/camera/camera_darwin.go
+++ b/pkg/driver/camera/camera_darwin.go
@@ -13,6 +13,7 @@ import (
 type camera struct {
 	device  avfoundation.Device
 	session *avfoundation.Session
+	rcClose func()
 }
 
 func init() {
@@ -43,6 +44,9 @@ func (cam *camera) Open() error {
 }
 
 func (cam *camera) Close() error {
+	if cam.rcClose != nil {
+		cam.rcClose()
+	}
 	return cam.session.Close()
 }
 
@@ -56,6 +60,7 @@ func (cam *camera) VideoRecord(property prop.Media) (video.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+	cam.rcClose = rc.Close
 	r := video.ReaderFunc(func() (image.Image, func(), error) {
 		frame, _, err := rc.Read()
 		if err != nil {


### PR DESCRIPTION
@lherman-cs, this fixes a goroutine leak:
```goroutine leak(s) detected: found unexpected goroutines:
[Goroutine 17 in state chan send, locked to thread, with github.com/pion/mediadevices/pkg/avfoundation.(*ReadCloser).dataCb on top of the stack:
goroutine 17 [chan send, locked to thread]:
github.com/pion/mediadevices/pkg/avfoundation.(*ReadCloser).dataCb(...)
	/Users/eric/mediadevices/pkg/avfoundation/avfoundation_darwin.go:112
github.com/pion/mediadevices/pkg/avfoundation.onData(0xc00000e080, 0x1174d0040, 0x2f8720)
	/Users/eric/mediadevices/pkg/avfoundation/avfoundation_callback_darwin.go:24 +0xb0

]```