### PR TITLE
Fixing Stride Handling for OpenH264

### DIFF
--- a/pkg/codec/openh264/bridge.cpp
+++ b/pkg/codec/openh264/bridge.cpp
@@ -88,9 +88,8 @@ Slice enc_encode(Encoder *e, Frame f, int *eresult) {
   pic.iPicWidth = f.width;
   pic.iPicHeight = f.height;
   pic.iColorFormat = videoFormatI420;
-  // We always received I420 format
-  pic.iStride[0] = pic.iPicWidth;
-  pic.iStride[1] = pic.iStride[2] = pic.iPicWidth / 2;
+  pic.iStride[0] = f.ystride;
+  pic.iStride[1] = pic.iStride[2] = f.cstride;
   pic.pData[0] = (unsigned char *)f.y;
   pic.pData[1] = (unsigned char *)f.u;
   pic.pData[2] = (unsigned char *)f.v;

--- a/pkg/codec/openh264/bridge.hpp
+++ b/pkg/codec/openh264/bridge.hpp
@@ -12,6 +12,8 @@ typedef struct Slice {
 
 typedef struct Frame {
   void *y, *u, *v;
+  int ystride;
+  int cstride;
   int height;
   int width;
 } Frame;

--- a/pkg/codec/openh264/openh264.go
+++ b/pkg/codec/openh264/openh264.go
@@ -65,11 +65,13 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	bounds := yuvImg.Bounds()
 	var rv C.int
 	s := C.enc_encode(e.engine, C.Frame{
-		y:      unsafe.Pointer(&yuvImg.Y[0]),
-		u:      unsafe.Pointer(&yuvImg.Cb[0]),
-		v:      unsafe.Pointer(&yuvImg.Cr[0]),
-		height: C.int(bounds.Max.Y - bounds.Min.Y),
-		width:  C.int(bounds.Max.X - bounds.Min.X),
+		y:       unsafe.Pointer(&yuvImg.Y[0]),
+		u:       unsafe.Pointer(&yuvImg.Cb[0]),
+		v:       unsafe.Pointer(&yuvImg.Cr[0]),
+		ystride: C.int(yuvImg.YStride),
+		cstride: C.int(yuvImg.CStride),
+		height:  C.int(bounds.Max.Y - bounds.Min.Y),
+		width:   C.int(bounds.Max.X - bounds.Min.X),
 	}, &rv)
 	if err := errResult(rv); err != nil {
 		return nil, func() {}, fmt.Errorf("failed in encoding: %v", err)


### PR DESCRIPTION
The golang image.YCbCr struct can contain fields of arbitrary stride
lengths, which don't necessarily match the field widths. This
patch passes the stride values from the image.YCbCr struct into
the OpenH264 encode calls.