### PR TITLE
Remove video framerate as explicit constraint

### DIFF
--- a/mediadevices_test.go
+++ b/mediadevices_test.go
@@ -125,18 +125,6 @@ func TestSelectBestDriverConstraintsResultIsSetProperly(t *testing.T) {
 			frameFormat: frame.FormatI420,
 			frameRate:   expectedProp.FrameRate,
 		},
-		"DifferentFrameRate": {
-			width:       expectedProp.Width,
-			height:      expectedProp.Height,
-			frameFormat: expectedProp.FrameFormat,
-			frameRate:   expectedProp.FrameRate - 1,
-		},
-		"NoFrameRateConstraints": {
-			width:       expectedProp.Width,
-			height:      expectedProp.Height,
-			frameFormat: expectedProp.FrameFormat,
-			frameRate:   -1,
-		},
 	}
 
 	for name, c := range cases {
@@ -228,12 +216,6 @@ func TestSelectBestDriverConstraintsNoFit(t *testing.T) {
 			height:      expectedProp.Height,
 			frameFormat: frame.FormatI420,
 			frameRate:   expectedProp.FrameRate,
-		},
-		"DifferentFrameRate": {
-			width:       expectedProp.Width,
-			height:      expectedProp.Height,
-			frameFormat: expectedProp.FrameFormat,
-			frameRate:   expectedProp.FrameRate - 1,
 		},
 	}
 

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -6,7 +6,6 @@ import "C"
 import (
 	"context"
 	"errors"
-	"fmt"
 	"image"
 	"io"
 	"os"
@@ -184,16 +183,6 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 		err = c.cam.SetFramerate(float32(p.FrameRate))
 		if err != nil {
 			return nil, err
-		}
-
-		framerate, err := c.cam.GetFramerate()
-		if err != nil {
-			return nil, err
-		}
-
-		if framerate != p.FrameRate {
-			// workaround to force a framerate constraint without using the MediaConstraints FitnessDistance function
-			return nil, fmt.Errorf("incompatible camera framerate: wants %f but got %f\n", p.FrameRate, framerate)
 		}
 	}
 

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -6,6 +6,7 @@ import "C"
 import (
 	"context"
 	"errors"
+	"fmt"
 	"image"
 	"io"
 	"os"
@@ -183,6 +184,16 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 		err = c.cam.SetFramerate(float32(p.FrameRate))
 		if err != nil {
 			return nil, err
+		}
+
+		framerate, err := c.cam.GetFramerate()
+		if err != nil {
+			return nil, err
+		}
+
+		if framerate != p.FrameRate {
+			// workaround to force a framerate constraint without using the MediaConstraints FitnessDistance function
+			return nil, fmt.Errorf("incompatible camera framerate: wants %f but got %f\n", p.FrameRate, framerate)
 		}
 	}
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -145,6 +145,11 @@ func (p *MediaConstraints) FitnessDistance(o Media) (float64, bool) {
 	cmps.add(p.Width, o.Width)
 	cmps.add(p.Height, o.Height)
 	cmps.add(p.FrameFormat, o.FrameFormat)
+	// The next line is comment out for now to not include framerate in the fitness function.
+	// As camera.Properties does not have access to the list of available framerate at the moment,
+	// no driver can be matched with a framerate constraint.
+	// Note this also affect screen caputre as screen.Properties does not fill in the Framerate field.
+	// cmps.add(p.FrameRate, o.FrameRate)
 	cmps.add(p.SampleRate, o.SampleRate)
 	cmps.add(p.Latency, o.Latency)
 	cmps.add(p.ChannelCount, o.ChannelCount)

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -145,14 +145,12 @@ func (p *MediaConstraints) FitnessDistance(o Media) (float64, bool) {
 	cmps.add(p.Width, o.Width)
 	cmps.add(p.Height, o.Height)
 	cmps.add(p.FrameFormat, o.FrameFormat)
-	cmps.add(p.FrameRate, o.FrameRate)
 	cmps.add(p.SampleRate, o.SampleRate)
 	cmps.add(p.Latency, o.Latency)
 	cmps.add(p.ChannelCount, o.ChannelCount)
 	cmps.add(p.IsBigEndian, o.IsBigEndian)
 	cmps.add(p.IsFloat, o.IsFloat)
 	cmps.add(p.IsInterleaved, o.IsInterleaved)
-
 	return cmps.fitnessDistance()
 }
 


### PR DESCRIPTION
#### Description
This PR addresses an issue introduced by changes from https://github.com/pion/mediadevices/pull/390: the video framerate was added as an explicit constraint to find a compatible driver. As `camera.Properties` currently does not have access to the list of available framerate no driver can be matched. Until this information can be retrieved it is better to not include the framerate in the fitness function. As a workaround, when a framerate is specified (i.e. > 0), a comparison between the desired value and the one reported by the device is performed and an error is returned when they are not equal. 