### PR TITLE
Allow to enable frame copy on a video track

### DIFF
--- a/track.go
+++ b/track.go
@@ -261,12 +261,20 @@ func newTrackFromDriver(d driver.Driver, constraints MediaTrackConstraints, sele
 type VideoTrack struct {
 	*baseTrack
 	*video.Broadcaster
-	ShouldCopyFrames bool
+	shouldCopyFrames bool
 }
 
 // NewVideoTrack constructs a new VideoTrack
 func NewVideoTrack(source VideoSource, selector *CodecSelector) Track {
 	return newVideoTrackFromReader(source, source, selector)
+}
+
+func (track *VideoTrack) ShouldCopyFrames() bool {
+	return track.shouldCopyFrames
+}
+
+func (track *VideoTrack) SetShouldCopyFrames(shouldCopyFrames bool) {
+	track.shouldCopyFrames = shouldCopyFrames
 }
 
 func newVideoTrackFromReader(source Source, reader video.Reader, selector *CodecSelector) Track {
@@ -313,7 +321,7 @@ func (track *VideoTrack) Unbind(ctx webrtc.TrackLocalContext) error {
 }
 
 func (track *VideoTrack) newEncodedReader(codecNames ...string) (EncodedReadCloser, *codec.RTPCodec, error) {
-	reader := track.NewReader(track.ShouldCopyFrames)
+	reader := track.NewReader(track.shouldCopyFrames)
 	inputProp, err := detectCurrentVideoProp(track.Broadcaster)
 	if err != nil {
 		return nil, nil, err

--- a/track.go
+++ b/track.go
@@ -269,10 +269,12 @@ func NewVideoTrack(source VideoSource, selector *CodecSelector) Track {
 	return newVideoTrackFromReader(source, source, selector)
 }
 
+// ShouldCopyFrames indicates if readers on this track should receive a clopy of the read buffer instead of sharing one.
 func (track *VideoTrack) ShouldCopyFrames() bool {
 	return track.shouldCopyFrames
 }
 
+// SetShouldCopyFrames enables frame copy for this track, sending each reader a different read buffer instead of sharing one.
 func (track *VideoTrack) SetShouldCopyFrames(shouldCopyFrames bool) {
 	track.shouldCopyFrames = shouldCopyFrames
 }

--- a/track.go
+++ b/track.go
@@ -261,6 +261,7 @@ func newTrackFromDriver(d driver.Driver, constraints MediaTrackConstraints, sele
 type VideoTrack struct {
 	*baseTrack
 	*video.Broadcaster
+	ShouldCopyFrames bool
 }
 
 // NewVideoTrack constructs a new VideoTrack
@@ -312,7 +313,7 @@ func (track *VideoTrack) Unbind(ctx webrtc.TrackLocalContext) error {
 }
 
 func (track *VideoTrack) newEncodedReader(codecNames ...string) (EncodedReadCloser, *codec.RTPCodec, error) {
-	reader := track.NewReader(false)
+	reader := track.NewReader(track.ShouldCopyFrames)
 	inputProp, err := detectCurrentVideoProp(track.Broadcaster)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
#### Description

This PR aims to give access to copy frame feature of `Broadcaster` in high level functions such as `track.NewEncodedReader()`.

Today, `track.New*Reader()` functions forces to disable frames copy from Broadcaster. This is not convenient when you want to use high level API with multiple readers, leading to video artefacts on some codec/frame format combination.

This API is not very elegant but doesn't introduce any complex or breaking changes.

