### PR TITLE
Use wanted RTP payload type

### DIFF
--- a/track.go
+++ b/track.go
@@ -68,7 +68,7 @@ type Track interface {
 	// the encoded data in RTP format with given mtu size.
 	//
 	// Note: `mtu int` will be changed to `mtu uint16` in a future update.
-	NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error)
+	NewRTPReader(codecName string, ssrc uint32, mtu int, payloadType uint8) (RTPReadCloser, error)
 	// NewEncodedReader creates a EncodedReadCloser that reads the encoded data in codecName format
 	NewEncodedReader(codecName string) (EncodedReadCloser, error)
 	// NewEncodedReader creates a new Go standard io.ReadCloser that reads the encoded data in codecName format
@@ -165,7 +165,7 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 	var errReasons []string
 	for _, wantedCodec := range ctx.CodecParameters() {
 		logger.Debugf("trying to build %s rtp reader", wantedCodec.MimeType)
-		encodedReader, err = specializedTrack.NewRTPReader(wantedCodec.MimeType, uint32(ctx.SSRC()), rtpOutboundMTU)
+		encodedReader, err = specializedTrack.NewRTPReader(wantedCodec.MimeType, uint32(ctx.SSRC()), rtpOutboundMTU, uint8(wantedCodec.PayloadType))
 		if err == nil {
 			selectedCodec = wantedCodec
 			break
@@ -351,13 +351,13 @@ func (track *VideoTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, er
 	return newEncodedIOReadCloserImpl(encodedReader), nil
 }
 
-func (track *VideoTrack) NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error) {
+func (track *VideoTrack) NewRTPReader(codecName string, ssrc uint32, mtu int, payloadType uint8) (RTPReadCloser, error) {
 	encodedReader, selectedCodec, err := track.newEncodedReader(codecName)
 	if err != nil {
 		return nil, err
 	}
 
-	packetizer := rtp.NewPacketizer(uint16(mtu), uint8(selectedCodec.PayloadType), ssrc, selectedCodec.Payloader, rtp.NewRandomSequencer(), selectedCodec.ClockRate)
+	packetizer := rtp.NewPacketizer(uint16(mtu), payloadType, ssrc, selectedCodec.Payloader, rtp.NewRandomSequencer(), selectedCodec.ClockRate)
 
 	return &rtpReadCloserImpl{
 		readFn: func() ([]*rtp.Packet, func(), error) {
@@ -471,13 +471,13 @@ func (track *AudioTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, er
 	return newEncodedIOReadCloserImpl(encodedReader), nil
 }
 
-func (track *AudioTrack) NewRTPReader(codecName string, ssrc uint32, mtu int) (RTPReadCloser, error) {
+func (track *AudioTrack) NewRTPReader(codecName string, ssrc uint32, mtu int, payloadType uint8) (RTPReadCloser, error) {
 	encodedReader, selectedCodec, err := track.newEncodedReader(codecName)
 	if err != nil {
 		return nil, err
 	}
 
-	packetizer := rtp.NewPacketizer(uint16(mtu), uint8(selectedCodec.PayloadType), ssrc, selectedCodec.Payloader, rtp.NewRandomSequencer(), selectedCodec.ClockRate)
+	packetizer := rtp.NewPacketizer(uint16(mtu), payloadType, ssrc, selectedCodec.Payloader, rtp.NewRandomSequencer(), selectedCodec.ClockRate)
 
 	return &rtpReadCloserImpl{
 		readFn: func() ([]*rtp.Packet, func(), error) {


### PR DESCRIPTION
#### Description

This PR updates the track implementation to use payload type ID requested by the client.

Without this fix when you run the webrtc example with a non Chromium browser, the client requests a payload type ID such as 126 and we reply with a different type ID, such as 125. When this happens the stream connects but there's no output. Any payload type ID in the range 96-127 is dynamic so we have to negotiate it.

This does fix my issue buy I''m not really sure if this is the best way to fix this. Do we need to support non dynamic payload types too? Do we need to validate bounds or anything?

#### Reference issue

Fixes this issue I accidentally opened on pion/webrtc repo: https://github.com/pion/webrtc/issues/2237