### PR TITLE
Camera timeout duration as parameter

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -192,13 +192,11 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 
 	cam := c.cam
 
-	// initialization
-	err = cam.WaitForFrame(5) // 5 seconds
-	switch err.(type) {
-	case nil:
-	case *webcam.Timeout:
-		return nil, errReadTimeout
-	default:
+	// wait up to 5 seconds to read the first frame
+	if err := cam.WaitForFrame(5); err != nil {
+		if _, ok := err.(*webcam.Timeout); ok {
+			return nil, errReadTimeout
+		}
 		// Camera has been stopped.
 		return nil, err
 	}

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -137,7 +137,7 @@ func newCamera(path string) *camera {
 func getCameraReadTimeout() uint32 {
 	// default to 5 seconds
 	var readTimeoutSec uint32 = 5
-	if val, ok := os.LookupEnv("CAMERA_READ_TIMEOUT"); ok {
+	if val, ok := os.LookupEnv("PION_MEDIADEVICES_CAMERA_READ_TIMEOUT"); ok {
 		if valInt, err := strconv.Atoi(val); err == nil {
 			if valInt > 0 {
 				readTimeoutSec = uint32(valInt)

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -206,14 +206,6 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 
 	cam := c.cam
 
-	// wait up to 5 seconds to read the first frame
-	if err := cam.WaitForFrame(5); err != nil {
-		if _, ok := err.(*webcam.Timeout); ok {
-			return nil, errReadTimeout
-		}
-		// Camera has been stopped.
-		return nil, err
-	}
 	readTimeoutSec := getCameraReadTimeout()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/driver/camera/camera_linux_test.go
+++ b/pkg/driver/camera/camera_linux_test.go
@@ -78,19 +78,20 @@ func TestGetCameraReadTimeout(t *testing.T) {
 		t.Errorf("Expected: %d, got: %d", expected, value)
 	}
 
-	os.Setenv("CAMERA_READ_TIMEOUT", "text")
+	envVarName := "PION_MEDIADEVICES_CAMERA_READ_TIMEOUT"
+	os.Setenv(envVarName, "text")
 	value = getCameraReadTimeout()
 	if value != expected {
 		t.Errorf("Expected: %d, got: %d", expected, value)
 	}
 
-	os.Setenv("CAMERA_READ_TIMEOUT", "-1")
+	os.Setenv(envVarName, "-1")
 	value = getCameraReadTimeout()
 	if value != expected {
 		t.Errorf("Expected: %d, got: %d", expected, value)
 	}
 
-	os.Setenv("CAMERA_READ_TIMEOUT", "1")
+	os.Setenv(envVarName, "1")
 	expected = 1
 	value = getCameraReadTimeout()
 	if value != expected {

--- a/pkg/driver/camera/camera_linux_test.go
+++ b/pkg/driver/camera/camera_linux_test.go
@@ -70,3 +70,30 @@ func TestDiscover(t *testing.T) {
 		t.Errorf("Expected label: %s, got: %s", expectedNoLink, label)
 	}
 }
+
+func TestGetCameraReadTimeout(t *testing.T) {
+	var expected uint32 = 5
+	value := getCameraReadTimeout()
+	if value != expected {
+		t.Errorf("Expected: %d, got: %d", expected, value)
+	}
+
+	os.Setenv("CAMERA_READ_TIMEOUT", "text")
+	value = getCameraReadTimeout()
+	if value != expected {
+		t.Errorf("Expected: %d, got: %d", expected, value)
+	}
+
+	os.Setenv("CAMERA_READ_TIMEOUT", "-1")
+	value = getCameraReadTimeout()
+	if value != expected {
+		t.Errorf("Expected: %d, got: %d", expected, value)
+	}
+
+	os.Setenv("CAMERA_READ_TIMEOUT", "1")
+	expected = 1
+	value = getCameraReadTimeout()
+	if value != expected {
+		t.Errorf("Expected: %d, got: %d", expected, value)
+	}
+}

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -229,18 +229,16 @@ func (c *comparisons) fitnessDistance() (float64, bool) {
 
 // VideoConstraints represents a video's constraints
 type VideoConstraints struct {
-	Width, Height  IntConstraint
-	FrameRate      FloatConstraint
-	FrameFormat    FrameFormatConstraint
-	ReadTimeoutSec IntConstraint
+	Width, Height IntConstraint
+	FrameRate     FloatConstraint
+	FrameFormat   FrameFormatConstraint
 }
 
 // Video represents a video's constraints
 type Video struct {
-	Width, Height  int
-	FrameRate      float32
-	FrameFormat    frame.Format
-	ReadTimeoutSec int
+	Width, Height int
+	FrameRate     float32
+	FrameFormat   frame.Format
 }
 
 // AudioConstraints represents an audio's constraints

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -229,16 +229,18 @@ func (c *comparisons) fitnessDistance() (float64, bool) {
 
 // VideoConstraints represents a video's constraints
 type VideoConstraints struct {
-	Width, Height IntConstraint
-	FrameRate     FloatConstraint
-	FrameFormat   FrameFormatConstraint
+	Width, Height  IntConstraint
+	FrameRate      FloatConstraint
+	FrameFormat    FrameFormatConstraint
+	ReadTimeoutSec IntConstraint
 }
 
 // Video represents a video's constraints
 type Video struct {
-	Width, Height int
-	FrameRate     float32
-	FrameFormat   frame.Format
+	Width, Height  int
+	FrameRate      float32
+	FrameFormat    frame.Format
+	ReadTimeoutSec int
 }
 
 // AudioConstraints represents an audio's constraints


### PR DESCRIPTION
#### Description

This PR adds a field to the `Video` and `VideoConstraints` to be able to set the timeout duration when reading frames from the video source. This field is not used in `fitnessDistance` and is only considered when set to a positive value. These changes should not modify the original behavior as the default value is kept to 5 seconds. 