### PR TITLE
Fix closing a camera not closing the associated track

### DIFF
--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -118,8 +118,8 @@ func (rc *ReadCloser) dataCb(data []byte) {
 		return
 	}
 	select {
+	// Use the Done channel to avoid waiting for new data from closed camera
 	case <-rc.cancelCtx.Done():
-		close(rc.dataChan)
 	case rc.dataChan <- data:
 	}
 }
@@ -141,6 +141,7 @@ func (rc *ReadCloser) Close() {
 		rc.onClose()
 	}
 	rc.cancelFunc()
+	close(rc.dataChan)
 	unregister(rc.id)
 }
 

--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -147,9 +147,9 @@ func (rc *ReadCloser) Close() {
 		rc.onClose()
 	}
 	rc.cancelFunc()
+	unregister(rc.id)
 	rc.closeWG.Wait()
 	close(rc.dataChan)
-	unregister(rc.id)
 }
 
 // Session represents a capturing session.


### PR DESCRIPTION
#### Description

Closing a record session on macOS does not close the reader.

This PR fixes this by closing the channel used to read incoming video frames directly in the Close function.
Calling it in the data callback is not working because since the record session is closed, the callback will never be called again. So the reader will indefinitely wait for a incoming frame/the channel to be closed, which will never happen.

By fixing this, i have also discover a bug, where closing a peer connection with some tracks already closed triggers a panic due to the stop mechanism.

#### Reference issue
Fixes #379
