### PR TITLE
fix nil reference when a read error occur with copyFrame enabled

### DIFF
--- a/pkg/io/broadcast.go
+++ b/pkg/io/broadcast.go
@@ -141,7 +141,9 @@ func (broadcaster *Broadcaster) NewReader(copyFn func(interface{}) interface{}) 
 			data, err, currentCount = ringData.data, ringData.err, ringData.count
 		}
 
-		data = copyFn(data)
+		if data != nil { // data is nil if an error occurred during reading
+			data = copyFn(data)
+		}
 		return
 	})
 }

--- a/pkg/io/video/broadcast_test.go
+++ b/pkg/io/video/broadcast_test.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"fmt"
 	"image"
 	"reflect"
 	"testing"
@@ -45,5 +46,23 @@ func TestBroadcast(t *testing.T) {
 
 	if !reflect.DeepEqual(img, actualWithCopy) {
 		t.Fatal("Expected actual frame without copy to be the same with the original")
+	}
+}
+
+func TestBroadcastWithCopyOnReadError(t *testing.T) {
+	expectedError := fmt.Errorf("expected error")
+	source := ReaderFunc(func() (image.Image, func(), error) {
+		return nil, func() {}, expectedError
+	})
+
+	broadcaster := NewBroadcaster(source, nil)
+	readerWithCopy := broadcaster.NewReader(true)
+	actualWithCopy, _, err := readerWithCopy.Read()
+
+	if actualWithCopy != nil {
+		t.Fatal("Expected actual frame with copy to be nil")
+	}
+	if err != expectedError {
+		t.Fatal("Expected error to be the same")
 	}
 }

--- a/pkg/io/video/broadcast_test.go
+++ b/pkg/io/video/broadcast_test.go
@@ -1,7 +1,7 @@
 package video
 
 import (
-	"fmt"
+	"errors"
 	"image"
 	"reflect"
 	"testing"
@@ -50,7 +50,7 @@ func TestBroadcast(t *testing.T) {
 }
 
 func TestBroadcastWithCopyOnReadError(t *testing.T) {
-	expectedError := fmt.Errorf("expected error")
+	expectedError := errors.New("expected error")
 	source := ReaderFunc(func() (image.Image, func(), error) {
 		return nil, func() {}, expectedError
 	})


### PR DESCRIPTION
#### Description

Fixes a nil pointer reference in the Broadcaster when using the `copyFrame` feature.
We were trying to copy the read buffer even if an error occured