### PR TITLE
fix race condition in i420 video converter leading to video artefacts

### DIFF
--- a/pkg/io/video/convert.go
+++ b/pkg/io/video/convert.go
@@ -71,13 +71,20 @@ func ToI420(r Reader) Reader {
 
 		imageToYCbCr(&yuvImg, img)
 
+		if yuvImg.SubsampleRatio == image.YCbCrSubsampleRatio420 {
+			return &yuvImg, func() {}, nil
+		}
+
+		// pixel format conversion functions modify the image internals, we have to make a copy to
+		// avoid concurrent encoders to convert multiple times the same frame
+		yuvImg := makeCopy(yuvImg, yuvImg.Cb, yuvImg.Cr)
+
 		// Covert pixel format to I420
 		switch yuvImg.SubsampleRatio {
 		case image.YCbCrSubsampleRatio444:
 			i444ToI420(&yuvImg)
 		case image.YCbCrSubsampleRatio422:
 			i422ToI420(&yuvImg)
-		case image.YCbCrSubsampleRatio420:
 		default:
 			return nil, func() {}, fmt.Errorf("unsupported pixel format: %s", yuvImg.SubsampleRatio)
 		}
@@ -85,6 +92,15 @@ func ToI420(r Reader) Reader {
 		yuvImg.SubsampleRatio = image.YCbCrSubsampleRatio420
 		return &yuvImg, func() {}, nil
 	})
+}
+
+func makeCopy(img image.YCbCr, cb, cr []uint8) image.YCbCr {
+	// We need to copy only Cb and Cr since this are the only data modify during resampling
+	img.Cb = make([]uint8, len(cb))
+	img.Cr = make([]uint8, len(cr))
+	copy(img.Cb, cb)
+	copy(img.Cr, cr)
+	return img
 }
 
 // imageToRGBA converts src to *image.RGBA and store it to dst

--- a/pkg/io/video/convert_cgo.c
+++ b/pkg/io/video/convert_cgo.c
@@ -3,6 +3,8 @@
 #include "_cgo_export.h"
 
 void i444ToI420CGO(
+    unsigned char *cb_dst,
+    unsigned char *cr_dst,
     unsigned char* cb,
     unsigned char* cr,
     const int stride, const int h)
@@ -22,8 +24,8 @@ void i444ToI420CGO(
           ((uint16_t)cr[isrc0] + (uint16_t)cr[isrc1] +
            (uint16_t)cr[isrc0 + 1] + (uint16_t)cr[isrc1 + 1]) /
           4;
-      cb[idst] = cb2;
-      cr[idst] = cr2;
+      cb_dst[idst] = cb2;
+      cr_dst[idst] = cr2;
       isrc0 += 2;
       isrc1 += 2;
       idst++;
@@ -34,6 +36,8 @@ void i444ToI420CGO(
 }
 
 void i422ToI420CGO(
+    unsigned char *cb_dst,
+    unsigned char *cr_dst,
     unsigned char* cb,
     unsigned char* cr,
     const int stride, const int h)
@@ -46,8 +50,8 @@ void i422ToI420CGO(
     {
       const uint8_t cb2 = ((uint16_t)cb[isrc] + (uint16_t)cb[isrc + stride]) / 2;
       const uint8_t cr2 = ((uint16_t)cr[isrc] + (uint16_t)cr[isrc + stride]) / 2;
-      cb[idst] = cb2;
-      cr[idst] = cr2;
+      cb_dst[idst] = cb2;
+      cr_dst[idst] = cr2;
       isrc++;
       idst++;
     }

--- a/pkg/io/video/convert_cgo.go
+++ b/pkg/io/video/convert_cgo.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package video
@@ -14,27 +15,35 @@ import "C"
 // All functions switched at runtime must be declared also in convert_nocgo.go.
 const hasCGOConvert = true
 
-func i444ToI420(img *image.YCbCr) {
+func i444ToI420(img image.YCbCr) image.YCbCr {
 	h := img.Rect.Dy()
+	cLen := img.CStride * h / 4
+	cbDst, crDst := make([]uint8, cLen), make([]uint8, cLen)
 	C.i444ToI420CGO(
+		(*C.uchar)(&cbDst[0]), (*C.uchar)(&crDst[0]),
 		(*C.uchar)(&img.Cb[0]), (*C.uchar)(&img.Cr[0]),
 		C.int(img.CStride), C.int(h),
 	)
 	img.CStride = img.CStride / 2
-	cLen := img.CStride * (h / 2)
-	img.Cb = img.Cb[:cLen]
-	img.Cr = img.Cr[:cLen]
+	img.Cb = cbDst
+	img.Cr = crDst
+	img.SubsampleRatio = image.YCbCrSubsampleRatio420
+	return img
 }
 
-func i422ToI420(img *image.YCbCr) {
+func i422ToI420(img image.YCbCr) image.YCbCr {
 	h := img.Rect.Dy()
+	cLen := img.CStride * (h / 2)
+	cbDst, crDst := make([]uint8, cLen), make([]uint8, cLen)
 	C.i422ToI420CGO(
+		(*C.uchar)(&cbDst[0]), (*C.uchar)(&crDst[0]),
 		(*C.uchar)(&img.Cb[0]), (*C.uchar)(&img.Cr[0]),
 		C.int(img.CStride), C.int(h),
 	)
-	cLen := img.CStride * (h / 2)
-	img.Cb = img.Cb[:cLen]
-	img.Cr = img.Cr[:cLen]
+	img.Cb = cbDst
+	img.Cr = crDst
+	img.SubsampleRatio = image.YCbCrSubsampleRatio420
+	return img
 }
 
 func rgbToYCbCrCGO(y, cb, cr *uint8, r, g, b uint8) { // For testing

--- a/pkg/io/video/convert_cgo.h
+++ b/pkg/io/video/convert_cgo.h
@@ -1,9 +1,13 @@
 void i444ToI420CGO(
+    unsigned char *cb_dst,
+    unsigned char *cr_dst,
     unsigned char* cb,
     unsigned char* cr,
     const int stride, const int h);
 
 void i422ToI420CGO(
+    unsigned char *cb_dst,
+    unsigned char *cr_dst,
     unsigned char* cb,
     unsigned char* cr,
     const int stride, const int h);

--- a/pkg/io/video/convert_nocgo.go
+++ b/pkg/io/video/convert_nocgo.go
@@ -1,3 +1,4 @@
+//go:build !cgo
 // +build !cgo
 
 package video
@@ -9,19 +10,22 @@ import (
 
 const hasCGOConvert = false
 
-func i444ToI420(img *image.YCbCr) {
+func i444ToI420(img image.YCbCr) image.YCbCr {
 	h := img.Rect.Dy()
 	addrSrc0 := 0
 	addrSrc1 := img.CStride
+	cLen := img.CStride * (h / 2)
 	addrDst := 0
+	cbDst, crDst := make([]uint8, cLen), make([]uint8, cLen)
+
 	for i := 0; i < h/2; i++ {
 		for j := 0; j < img.CStride/2; j++ {
 			cb := uint16(img.Cb[addrSrc0]) + uint16(img.Cb[addrSrc1]) +
 				uint16(img.Cb[addrSrc0+1]) + uint16(img.Cb[addrSrc1+1])
 			cr := uint16(img.Cr[addrSrc0]) + uint16(img.Cr[addrSrc1]) +
 				uint16(img.Cr[addrSrc0+1]) + uint16(img.Cr[addrSrc1+1])
-			img.Cb[addrDst] = uint8(cb / 4)
-			img.Cr[addrDst] = uint8(cr / 4)
+			cbDst[addrDst] = uint8(cb / 4)
+			crDst[addrDst] = uint8(cr / 4)
 			addrSrc0 += 2
 			addrSrc1 += 2
 			addrDst++
@@ -30,29 +34,34 @@ func i444ToI420(img *image.YCbCr) {
 		addrSrc1 += img.CStride
 	}
 	img.CStride = img.CStride / 2
-	cLen := img.CStride * (h / 2)
-	img.Cb = img.Cb[:cLen]
-	img.Cr = img.Cr[:cLen]
+	img.Cb = cbDst
+	img.Cr = crDst
+	img.SubsampleRatio = image.YCbCrSubsampleRatio420
+	return img
 }
 
-func i422ToI420(img *image.YCbCr) {
+func i422ToI420(img image.YCbCr) image.YCbCr {
 	h := img.Rect.Dy()
 	addrSrc := 0
+	cLen := img.CStride * (h / 2)
+	cbDst, crDst := make([]uint8, cLen), make([]uint8, cLen)
 	addrDst := 0
+
 	for i := 0; i < h/2; i++ {
 		for j := 0; j < img.CStride; j++ {
 			cb := uint16(img.Cb[addrSrc]) + uint16(img.Cb[addrSrc+img.CStride])
 			cr := uint16(img.Cr[addrSrc]) + uint16(img.Cr[addrSrc+img.CStride])
-			img.Cb[addrDst] = uint8(cb / 2)
-			img.Cr[addrDst] = uint8(cr / 2)
-			addrDst++
+			cbDst[addrDst] = uint8(cb / 4)
+			crDst[addrDst] = uint8(cr / 4)
 			addrSrc++
+			addrDst++
 		}
 		addrSrc += img.CStride
 	}
-	cLen := img.CStride * (h / 2)
-	img.Cb = img.Cb[:cLen]
-	img.Cr = img.Cr[:cLen]
+	img.Cb = cbDst
+	img.Cr = crDst
+	img.SubsampleRatio = image.YCbCrSubsampleRatio420
+	return img
 }
 
 func i444ToRGBA(dst *image.RGBA, src *image.YCbCr) {

--- a/pkg/io/video/convert_test.go
+++ b/pkg/io/video/convert_test.go
@@ -222,8 +222,8 @@ func BenchmarkToI420(b *testing.B) {
 			"RGBA": image.NewRGBA(image.Rect(0, 0, sz[0], sz[1])),
 		}
 		b.Run(name, func(b *testing.B) {
-			for name, img := range cases {
-				img := img
+			for _, name := range [...]string{"I444", "I422", "I420", "RGBA"} {
+				img := cases[name]
 				b.Run(name, func(b *testing.B) {
 					r := ToI420(ReaderFunc(func() (image.Image, func(), error) {
 						return img, func() {}, nil


### PR DESCRIPTION
#### Description

Fixes a race condition in the i420 video converter leading to artefacts when used in concurrently.

A way to see it in action is to create 2 x264 video encoder for the same video track with a video source using i422 or i444 color space. This triggers a bug where we don't convert the entire image, we only resample it, probably to avoid unecessary memory allocation. But when multiple encoders uses this converter at the same time, it will resample multiple time with the same original sample ration, leading to weird artefacts.

There is probably 2 way to fix this:
 - add locks to avoid concurrent modifications
 - make a copy when doing destructive operation

I have implemented the later one in this PR since adding a lock would be difficult, necessitating to be aware of it everywhere the frame is used. I think the simplicity to have a very local fix covers the additional memory and cpu consumption. 
