### PR TITLE
allow to close the avfoundation device multiple time

### DIFF
--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -100,8 +100,8 @@ type ReadCloser struct {
 	onClose    func()
 	cancelCtx  context.Context
 	cancelFunc func()
-	closeWG    *sync.WaitGroup
-	lock       *sync.Mutex
+	closeWG    sync.WaitGroup
+	lock       sync.Mutex
 }
 
 func newReadCloser(onClose func()) *ReadCloser {
@@ -112,8 +112,6 @@ func newReadCloser(onClose func()) *ReadCloser {
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	rc.cancelCtx = cancelCtx
 	rc.cancelFunc = cancelFunc
-	rc.closeWG = &sync.WaitGroup{}
-	rc.lock = &sync.Mutex{}
 	return &rc
 }
 
@@ -165,13 +163,13 @@ func (rc *ReadCloser) Close() {
 type Session struct {
 	device   Device
 	cSession C.PAVBindSession
-	lock     *sync.Mutex
+	lock     sync.Mutex
 	closed   bool
 }
 
 // NewSession creates a new capturing session
 func NewSession(device Device) (*Session, error) {
-	session := Session{lock: &sync.Mutex{}}
+	session := Session{}
 
 	status := C.AVBindSessionInit(device.cDevice, &session.cSession)
 	if status != nil {

--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -169,7 +169,7 @@ type Session struct {
 
 // NewSession creates a new capturing session
 func NewSession(device Device) (*Session, error) {
-	session := Session{}
+	var session Session
 
 	status := C.AVBindSessionInit(device.cDevice, &session.cSession)
 	if status != nil {


### PR DESCRIPTION
#### Description

Allow to close multiple time an avfoundation. For now, when closing an alreacy closed VideoTrack comming from avfoundation leads to a panic (close of closed channel)
