### PR TITLE
fix PLI and FIR handling, wrongly triggering track.OnEnded

### DIFF
--- a/track.go
+++ b/track.go
@@ -246,16 +246,14 @@ func (track *baseTrack) rtcpReadLoop(reader interceptor.RTCPReader, keyFrameCont
 
 		pkts, err := rtcp.Unmarshal(readerBuffer[:readLength])
 		if err != nil {
-			track.onError(err)
-			return
+			logger.Warnf("failed to unmarshal rtcp packet: %s", err)
 		}
 
 		for _, pkt := range pkts {
 			switch pkt.(type) {
 			case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest:
 				if err := keyFrameController.ForceKeyFrame(); err != nil {
-					track.onError(err)
-					return
+					logger.Warnf("failed to force key frame: %s", err)
 				}
 			}
 		}

--- a/track_test.go
+++ b/track_test.go
@@ -2,6 +2,8 @@ package mediadevices
 
 import (
 	"errors"
+	"github.com/pion/interceptor"
+	"io"
 	"testing"
 	"time"
 )
@@ -50,6 +52,104 @@ func TestOnEnded(t *testing.T) {
 			}
 		case <-time.After(10 * time.Millisecond):
 			t.Error("Timeout")
+		}
+	})
+}
+
+type fakeRTCPReader struct {
+	mockReturn chan []byte
+	end        chan struct{}
+}
+
+func (mock *fakeRTCPReader) Read(buffer []byte, attributes interceptor.Attributes) (int, interceptor.Attributes, error) {
+	select {
+	case <-mock.end:
+		return 0, nil, io.EOF
+	case mockReturn := <-mock.mockReturn:
+		if len(buffer) < len(mock.mockReturn) {
+			return 0, nil, io.ErrShortBuffer
+		}
+
+		return copy(buffer, mockReturn), attributes, nil
+	}
+}
+
+type fakeKeyFrameController struct {
+	called chan struct{}
+}
+
+func (mock *fakeKeyFrameController) ForceKeyFrame() error {
+	mock.called <- struct{}{}
+	return nil
+}
+
+func TestRtcpHandler(t *testing.T) {
+
+	t.Run("ShouldStopReading", func(t *testing.T) {
+		tr := &baseTrack{}
+		stop := make(chan struct{}, 1)
+		stopped := make(chan struct{})
+		go func() {
+			tr.rtcpReadLoop(&fakeRTCPReader{end: stop}, &fakeKeyFrameController{}, stop)
+			stopped <- struct{}{}
+		}()
+
+		stop <- struct{}{}
+
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Timeout")
+		case <-stopped:
+		}
+	})
+
+	t.Run("ShouldForceKeyFrame", func(t *testing.T) {
+		for packetType, packet := range map[string][]byte{
+			"PLI": {
+				// v=2, p=0, FMT=1, PSFB, len=1
+				0x81, 0xce, 0x00, 0x02,
+				// ssrc=0x0
+				0x00, 0x00, 0x00, 0x00,
+				// ssrc=0x4bc4fcb4
+				0x4b, 0xc4, 0xfc, 0xb4,
+			},
+			"FIR": {
+				// v=2, p=0, FMT=4, PSFB, len=3
+				0x84, 0xce, 0x00, 0x04,
+				// ssrc=0x0
+				0x00, 0x00, 0x00, 0x00,
+				// ssrc=0x4bc4fcb4
+				0x4b, 0xc4, 0xfc, 0xb4,
+				// ssrc=0x12345678
+				0x12, 0x34, 0x56, 0x78,
+				// Seqno=0x42
+				0x42, 0x00, 0x00, 0x00,
+			},
+		} {
+			t.Run(packetType, func(t *testing.T) {
+				tr := &baseTrack{}
+				tr.OnEnded(func(err error) {
+					if err != io.EOF {
+						t.Error(err)
+					}
+				})
+				stop := make(chan struct{}, 1)
+				defer func() {
+					stop <- struct{}{}
+				}()
+				mockKeyFrameController := &fakeKeyFrameController{called: make(chan struct{}, 1)}
+				mockRTCPReader := &fakeRTCPReader{end: stop, mockReturn: make(chan []byte, 1)}
+
+				go tr.rtcpReadLoop(mockRTCPReader, mockKeyFrameController, stop)
+
+				mockRTCPReader.mockReturn <- packet
+
+				select {
+				case <-time.After(1000 * time.Millisecond):
+					t.Error("Timeout")
+				case <-mockKeyFrameController.called:
+				}
+			})
 		}
 	})
 }


### PR DESCRIPTION
#### Description

Fix the newly added PLI and FIR handling. An error has been introduce when merging the PR.

We were reading with an empty buffer, which lead to `io.ErrShortBuffer` error. This was causing the RTCP read loop to crash, but the track remained sending video, since the reading and writing loops were not linked.

A potentially breaking side effect was also the call to `track.OnEnded`, while the track didn't realy ended in facts.

I'm fixing this by using a buffer of 1500 bytes (from what I have found in different examples), and closing the track when read errors occurs.