### PR TITLE
rename opus C function to be compatible with other opus modules

### DIFF
--- a/pkg/codec/opus/opus.go
+++ b/pkg/codec/opus/opus.go
@@ -110,7 +110,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 }
 
 func (e *encoder) SetBitRate(bitRate int) error {
-	cerror := C.set_encoder_bitrate(
+	cerror := C.pion_set_encoder_bitrate(
 		e.engine,
 		C.int(bitRate),
 	)

--- a/pkg/codec/opus/opus.go
+++ b/pkg/codec/opus/opus.go
@@ -14,7 +14,7 @@ import (
 /*
 #include <opus.h>
 
-int bridge_encoder_set_bitrate(OpusEncoder *e, opus_int32 bitrate)
+int set_encoder_bitrate(OpusEncoder *e, opus_int32 bitrate)
 {
 	return opus_encoder_ctl(e, OPUS_SET_BITRATE(bitrate));
 }
@@ -110,7 +110,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 }
 
 func (e *encoder) SetBitRate(bitRate int) error {
-	cerror := C.bridge_encoder_set_bitrate(
+	cerror := C.set_encoder_bitrate(
 		e.engine,
 		C.int(bitRate),
 	)

--- a/pkg/codec/opus/opus.go
+++ b/pkg/codec/opus/opus.go
@@ -14,7 +14,7 @@ import (
 /*
 #include <opus.h>
 
-int set_encoder_bitrate(OpusEncoder *e, opus_int32 bitrate)
+int pion_set_encoder_bitrate(OpusEncoder *e, opus_int32 bitrate)
 {
 	return opus_encoder_ctl(e, OPUS_SET_BITRATE(bitrate));
 }


### PR DESCRIPTION
#### Description

Renaming the C bitrate setter function allow to be combatible with `gopkg.in/hraban/opus.v2` (an opus decoder package)

#### Reference issue
Fixes #362
