### PR TITLE
Properly close microphone before malgo chunk channel

### DIFF
--- a/pkg/driver/microphone/microphone.go
+++ b/pkg/driver/microphone/microphone.go
@@ -93,10 +93,6 @@ func (m *microphone) Close() error {
 	if m.deviceCloseFunc != nil {
 		m.deviceCloseFunc()
 	}
-	if m.chunkChan != nil {
-		close(m.chunkChan)
-		m.chunkChan = nil
-	}
 	return nil
 }
 
@@ -153,6 +149,11 @@ func (m *microphone) AudioRecord(inputProp prop.Media) (audio.Reader, error) {
 		closeDeviceOnce.Do(func() {
 			cancel() // Unblock onRecvChunk
 			device.Uninit()
+
+			if m.chunkChan != nil {
+				close(m.chunkChan)
+				m.chunkChan = nil
+			}
 		})
 	}
 

--- a/pkg/driver/microphone/microphone.go
+++ b/pkg/driver/microphone/microphone.go
@@ -152,7 +152,6 @@ func (m *microphone) AudioRecord(inputProp prop.Media) (audio.Reader, error) {
 	m.deviceCloseFunc = func() {
 		closeDeviceOnce.Do(func() {
 			cancel() // Unblock onRecvChunk
-			device.Stop()
 			device.Uninit()
 		})
 	}


### PR DESCRIPTION
Prior to this, there's a chance you would close the chunk channel while malgo is trying to send on it. Instead, it's better to stop the malgo device and then close. That also means we need to discard chunks when trying to stop due to the buffered channel.