### PR TITLE
Skip vaapi test on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,7 @@ jobs:
             libopus-dev \
             libva-dev \
             libvpx-dev \
-            libx264-dev \
-            vainfo
-      - name: Debug
-        run: sudo vainfo
-      - name: Fix DRI permission
-        run: sudo chmod o+rw /dev/dri/card*
+            libx264-dev
       - name: Run Test Suite
         run: make test
       - uses: codecov/codecov-action@v3	

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,8 @@ jobs:
             libopus-dev \
             libva-dev \
             libvpx-dev \
-            libx264-dev
+            libx264-dev \
+            vainfo
       - name: Debug
         run: sudo vainfo
       - name: Fix DRI permission

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
         run: |
           id
           ls -la /dev/dri/*
+          sudo chmod o+rw /dev/dri/card*
       - name: Run Test Suite
         run: make test
       - uses: codecov/codecov-action@v3	

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,9 @@ jobs:
             libvpx-dev \
             libx264-dev
       - name: Debug
-        run: |
-          id
-          ls -la /dev/dri/*
-          sudo chmod o+rw /dev/dri/card*
+        run: sudo vainfo
+      - name: Fix DRI permission
+        run: sudo chmod o+rw /dev/dri/card*
       - name: Run Test Suite
         run: make test
       - uses: codecov/codecov-action@v3	

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,10 @@ jobs:
             libva-dev \
             libvpx-dev \
             libx264-dev
+      - name: Debug
+        run: |
+          id
+          ls -la /dev/dri/*
       - name: Run Test Suite
         run: make test
       - uses: codecov/codecov-action@v3	

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ codec_dir := pkg/codec
 codec_list := $(shell ls $(codec_dir)/*/Makefile)
 codec_list := $(codec_list:$(codec_dir)/%/Makefile=%)
 targets := $(foreach codec, $(codec_list), $(addprefix $(cmd_build)-$(codec)-, $(supported_platforms)))
-pkgs_without_mmal := $(shell go list ./... | grep -v mmal)
+pkgs_without_ext_device := $(shell go list ./... | grep -v mmal | grep -v vaapi)
 pkgs_without_cgo := $(shell go list ./... | grep -v pkg/codec | grep -v pkg/driver | grep -v pkg/avfoundation)
 
 define BUILD_TEMPLATE
@@ -73,11 +73,11 @@ $(foreach codec, $(codec_list), \
 # Description:
 # 	Run a series of tests
 $(cmd_test):
-	go vet $(pkgs_without_mmal)
-	go build $(pkgs_without_mmal)
+	go vet $(pkgs_without_ext_device)
+	go build $(pkgs_without_ext_device)
 	# go build without CGO
 	CGO_ENABLED=0 go build $(pkgs_without_cgo)
 	# go build with CGO
-	CGO_ENABLED=1 go build $(pkgs_without_mmal)
+	CGO_ENABLED=1 go build $(pkgs_without_ext_device)
 	$(MAKE) --directory=$(examples_dir)
-	go test -v -race -coverprofile=coverage.txt -covermode=atomic $(pkgs_without_mmal)
+	go test -v -race -coverprofile=coverage.txt -covermode=atomic $(pkgs_without_ext_device)


### PR DESCRIPTION
DRI device appears on GitHub Actions runner but unusable. (`vainfo` errors as well)
Skip `pkg/codec/vaapi` on CI.