### PR TITLE
Add missing EnablePictureID in VP8Payloader

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -50,7 +50,9 @@ func NewRTPVP8Codec(clockrate uint32) *RTPCodec {
 			},
 			PayloadType: 96,
 		},
-		Payloader: &codecs.VP8Payloader{},
+		Payloader: &codecs.VP8Payloader{
+			EnablePictureID: true,
+		},
 	}
 }
 


### PR DESCRIPTION
The EnablePictureID param is required to create the extended RTP VP8 header. Without this header the VP8 streams cannot be read by the Mediasoup SFU.

#### Description

#### Reference issue

