### PR TITLE
Fix for preventing close of stopRead nil channel

### DIFF
--- a/track.go
+++ b/track.go
@@ -187,7 +187,10 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 		var doneCh chan<- struct{}
 		writer := ctx.WriteStream()
 		defer func() {
-			close(stopRead)
+			if stopRead != nil {
+				close(stopRead)
+			}
+
 			encodedReader.Close()
 
 			// When there's another call to unbind, it won't block since we remove the current ctx from active connections


### PR DESCRIPTION
#### Description
The behaviour is described here: https://github.com/pion/mediadevices/issues/457
The issue is opened for Windows, but it occurs on Raspbian as well.  Can't reproduce it on macOS.
Noticed this issue after migrating mediadevices from v0.3.7 to v0.3.10 

#### Reference issue
https://github.com/pion/mediadevices/issues/457
Fixes #457 
