### PR TITLE
Fix deadlock in track.Bind()

### DIFF
--- a/track.go
+++ b/track.go
@@ -172,10 +172,14 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 	for _, wantedCodec := range ctx.CodecParameters() {
 		logger.Debugf("trying to build %s rtp reader", wantedCodec.MimeType)
 		encodedReader, err = specializedTrack.NewRTPReader(wantedCodec.MimeType, uint32(ctx.SSRC()), rtpOutboundMTU)
+
+		track.errMu.Lock()
 		if track.err != nil {
 			err = track.err
 			encodedReader = nil
 		}
+		track.errMu.Unlock()
+
 		if err == nil {
 			selectedCodec = wantedCodec
 			break

--- a/track.go
+++ b/track.go
@@ -83,6 +83,7 @@ type baseTrack struct {
 	Source
 	err                   error
 	onErrorHandler        func(error)
+	errMu                 sync.Mutex
 	mu                    sync.Mutex
 	endOnce               sync.Once
 	kind                  MediaDeviceType
@@ -129,10 +130,10 @@ func (track *baseTrack) RID() string {
 // OnEnded sets an error handler. When a track has been created and started, if an
 // error occurs, handler will get called with the error given to the parameter.
 func (track *baseTrack) OnEnded(handler func(error)) {
-	track.mu.Lock()
+	track.errMu.Lock()
 	track.onErrorHandler = handler
 	err := track.err
-	track.mu.Unlock()
+	track.errMu.Unlock()
 
 	if err != nil && handler != nil {
 		// Already errored.
@@ -144,10 +145,10 @@ func (track *baseTrack) OnEnded(handler func(error)) {
 
 // onError is a callback when an error occurs
 func (track *baseTrack) onError(err error) {
-	track.mu.Lock()
+	track.errMu.Lock()
 	track.err = err
 	handler := track.onErrorHandler
-	track.mu.Unlock()
+	track.errMu.Unlock()
 
 	if handler != nil {
 		track.endOnce.Do(func() {
@@ -171,6 +172,10 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 	for _, wantedCodec := range ctx.CodecParameters() {
 		logger.Debugf("trying to build %s rtp reader", wantedCodec.MimeType)
 		encodedReader, err = specializedTrack.NewRTPReader(wantedCodec.MimeType, uint32(ctx.SSRC()), rtpOutboundMTU)
+		if track.err != nil {
+			err = track.err
+			encodedReader = nil
+		}
 		if err == nil {
 			selectedCodec = wantedCodec
 			break


### PR DESCRIPTION
#### Description

Occurs when read errors happen from a
driver source during a call to track.Bind()

Example of deadlock:
1. When a driver reader function has a read error immediately after being initialized: contrived example:
```golang
video.ReaderFunc(func() (image.Image, func(), error) {
	return nil, nil, errors.New("Ahhhh")
})
```

2. Pion calls bind() on a track using that reader function.
3. Within NewRTPReader():
    a. The reader function is wrapped to call track.onError if a read error is returned in newVideoTrackFromReader()
    b. Read is called synchronously in detectCurrentVideoProp() in the function newEncodedReader()
    c.  track.onError() is triggered within the bind function (so without this fix, the mutex lock on bind() will not yet be released, and would deadlock in track.onError())
		