### PR TITLE
fix(`baseTrack`): panic on close of nil channel

### DIFF
--- a/track.go
+++ b/track.go
@@ -196,7 +196,9 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 		var doneCh chan<- struct{}
 		writer := ctx.WriteStream()
 		defer func() {
-			close(stopRead)
+			if stopRead != nil {
+				close(stopRead)
+			}
 			encodedReader.Close()
 
 			// When there's another call to unbind, it won't block since we remove the current ctx from active connections


### PR DESCRIPTION
```
panic: close of nil channel

goroutine 281 [running]:
github.com/pion/mediadevices.(*baseTrack).bind.func1.1()
	/Users/naruto/go/pkg/mod/github.com/pion/mediadevices@v0.3.12/track.go:190 +0x54
github.com/pion/mediadevices.(*baseTrack).bind.func1()
	/Users/naruto/go/pkg/mod/github.com/pion/mediadevices@v0.3.12/track.go:204 +0x120
created by github.com/pion/mediadevices.(*baseTrack).bind
	/Users/naruto/go/pkg/mod/github.com/pion/mediadevices@v0.3.12/track.go:186 +0x30c


Process finished with the exit code 1
```