### PR TITLE
Expose name of devices along with UID for macOS

### DIFF
--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
@@ -27,6 +27,7 @@
 #define MAX_DEVICES                      8
 #define MAX_PROPERTIES                   64
 #define MAX_DEVICE_UID_CHARS             64
+#define MAX_DEVICE_NAME_CHARS            64
 
 typedef const char* STATUS;
 static STATUS STATUS_OK                       = (STATUS) NULL;
@@ -65,6 +66,7 @@ typedef struct AVBindSession AVBindSession, *PAVBindSession;
 
 typedef struct {
     char uid[MAX_DEVICE_UID_CHARS + 1];
+    char name[MAX_DEVICE_NAME_CHARS + 1];
 } AVBindDevice, *PAVBindDevice;
 
 // AVBindDevices returns a list of AVBindDevices. The result array is pointing to a static

--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
@@ -201,6 +201,8 @@ STATUS AVBindDevices(AVBindMediaType mediaType, PAVBindDevice *ppDevices, int *p
         pDevice = devices + i;
         strncpy(pDevice->uid, refDevice.uniqueID.UTF8String, MAX_DEVICE_UID_CHARS);
         pDevice->uid[MAX_DEVICE_UID_CHARS] = '\0';
+        strncpy(pDevice->name, refDevice.localizedName.UTF8String, MAX_DEVICE_NAME_CHARS);
+        pDevice->name[MAX_DEVICE_NAME_CHARS] = '\0';
         i++;
     }
 

--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -34,6 +34,7 @@ type Device struct {
 	// UID is a unique identifier for a device
 	UID     string
 	cDevice C.AVBindDevice
+	Name    string
 }
 
 func frameFormatToAVBind(f frame.Format) (C.AVBindFrameFormat, bool) {
@@ -87,6 +88,7 @@ func Devices(mediaType MediaType) ([]Device, error) {
 	for i := range devices {
 		devices[i].UID = C.GoString(&cDevices[i].uid[0])
 		devices[i].cDevice = cDevices[i]
+		devices[i].Name = C.GoString(&cDevices[i].name[0])
 	}
 
 	return devices, nil

--- a/pkg/driver/camera/camera_darwin.go
+++ b/pkg/driver/camera/camera_darwin.go
@@ -32,6 +32,7 @@ func Initialize() {
 		driver.GetManager().Register(cam, driver.Info{
 			Label:      device.UID,
 			DeviceType: driver.Camera,
+			Name:       device.Name,
 		})
 	}
 }

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -116,7 +116,6 @@ func discover(discovered map[string]struct{}, pattern string) {
 			Label:      label + LabelSeparator + reallink,
 			DeviceType: driver.Camera,
 			Priority:   priority,
-			Name:       label,
 		})
 	}
 }

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -116,6 +116,7 @@ func discover(discovered map[string]struct{}, pattern string) {
 			Label:      label + LabelSeparator + reallink,
 			DeviceType: driver.Camera,
 			Priority:   priority,
+			Name:       label,
 		})
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -30,6 +30,7 @@ type Info struct {
 	Label      string
 	DeviceType DeviceType
 	Priority   Priority
+	Name       string
 }
 
 type Adapter interface {


### PR DESCRIPTION
#### Description
As it is currently implemented, the only way to identify a device plugged into a Darwin system is by `UID` even though many other forms of identification exist for each device, as explained in this [_Identifying a Device_](https://developer.apple.com/documentation/avfoundation/avcapturedevice) section of the AVFoundation documentation. This change exposes the `localizedName` and adds it as `Name` to the `avfoundation.Device` type struct. Additionally, the name is added to the `driver.Info` type struct so that it is included when registering a device.
#### Reasoning
While the `UID` that is currently registered for each device is helpful, it is not human readable, unlike `localizedName`. For example, when discovering the devices on a MacBook, the built in webcam's `UID` is a string of numbers, letters, and dashes, but it's `localizedName` is "FaceTime HD Camera". Exposing this name would be helpful for any human interactive use cases, but UID will also remain available for any other use cases in which it is better suited. 
