### PR TITLE
Add YUYV to supported video formats

### DIFF
--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.h
@@ -47,7 +47,7 @@ typedef enum AVBindFrameFormat {
     AVBindFrameFormatI420,
     AVBindFrameFormatNV21,
     AVBindFrameFormatNV12,
-    AVBindFrameFormatYUY2,
+    AVBindFrameFormatYUYV,
     AVBindFrameFormatUYVY,
 } AVBindFrameFormat;
 

--- a/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
+++ b/pkg/avfoundation/AVFoundationBind/AVFoundationBind.m
@@ -139,7 +139,7 @@ STATUS frameFormatToFourCC(AVBindFrameFormat format, FourCharCode *pFourCC) {
         case AVBindFrameFormatUYVY:
             *pFourCC = kCVPixelFormatType_422YpCbCr8;
             break;
-        case AVBindFrameFormatYUY2:
+        case AVBindFrameFormatYUYV:
             *pFourCC = kCVPixelFormatType_422YpCbCr8_yuvs;
             break;
         // TODO: Add the rest of frame formats
@@ -163,7 +163,7 @@ STATUS frameFormatFromFourCC(FourCharCode fourCC, AVBindFrameFormat *pFormat) {
             *pFormat = AVBindFrameFormatUYVY;
             break;
         case kCVPixelFormatType_422YpCbCr8_yuvs:
-            *pFormat = AVBindFrameFormatYUY2;
+            *pFormat = AVBindFrameFormatYUYV;
             break;
          // TODO: Add the rest of frame formats
         default:

--- a/pkg/avfoundation/avfoundation_darwin.go
+++ b/pkg/avfoundation/avfoundation_darwin.go
@@ -45,8 +45,8 @@ func frameFormatToAVBind(f frame.Format) (C.AVBindFrameFormat, bool) {
 		return C.AVBindFrameFormatNV21, true
 	case frame.FormatNV12:
 		return C.AVBindFrameFormatNV12, true
-	case frame.FormatYUY2:
-		return C.AVBindFrameFormatYUY2, true
+	case frame.FormatYUYV:
+		return C.AVBindFrameFormatYUYV, true
 	case frame.FormatUYVY:
 		return C.AVBindFrameFormatUYVY, true
 	default:
@@ -62,8 +62,8 @@ func frameFormatFromAVBind(f C.AVBindFrameFormat) (frame.Format, bool) {
 		return frame.FormatNV21, true
 	case C.AVBindFrameFormatNV12:
 		return frame.FormatNV12, true
-	case C.AVBindFrameFormatYUY2:
-		return frame.FormatYUY2, true
+	case C.AVBindFrameFormatYUYV:
+		return frame.FormatYUYV, true
 	case C.AVBindFrameFormatUYVY:
 		return frame.FormatUYVY, true
 	default:

--- a/pkg/frame/decode.go
+++ b/pkg/frame/decode.go
@@ -7,25 +7,26 @@ import (
 type Format string
 
 const (
-	// FormatI420 https://www.fourcc.org/pixel-format/yuv-i420/
+	// FormatI420 https://wiki.videolan.org/YUV#I420
 	FormatI420 Format = "I420"
 	// FormatI444 is a YUV format without sub-sampling
 	FormatI444 Format = "I444"
-	// FormatNV21 https://www.fourcc.org/pixel-format/yuv-nv21/
+	// FormatNV21 https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-nv12.html
 	FormatNV21 = "NV21"
-	// FormatNV12 https://www.fourcc.org/pixel-format/yuv-nv12/
+	// FormatNV12 https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-nv12.html
 	FormatNV12 = "NV12"
-	// FormatYUY2 https://www.fourcc.org/pixel-format/yuv-yuy2/
+	// FormatYUY2 https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-yuyv.html
+	// YUY2 is what Windows calls YUYV
 	FormatYUY2 = "YUY2"
-	// FormatYUYV https://www.fourcc.org/pixel-format/yuv-yuy2/
+	// FormatYUYV https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-yuyv.html
 	FormatYUYV = "YUYV"
-	// FormatUYVY https://www.fourcc.org/pixel-format/yuv-uyvy/
+	// FormatUYVY https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-uyvy.html
 	FormatUYVY = "UYVY"
 
-	// FormatRGBA https://www.fourcc.org/pixel-format/rgb-rgba/
+	// FormatRGBA https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-rgb.html
 	FormatRGBA Format = "RGBA"
 
-	// FormatMJPEG https://www.fourcc.org/mjpg/
+	// FormatMJPEG https://wiki.videolan.org/MJPEG
 	FormatMJPEG = "MJPEG"
 
 	// FormatZ16 https://www.kernel.org/doc/html/v5.9/userspace-api/media/v4l/pixfmt-z16.html

--- a/pkg/frame/decode.go
+++ b/pkg/frame/decode.go
@@ -17,6 +17,8 @@ const (
 	FormatNV12 = "NV12"
 	// FormatYUY2 https://www.fourcc.org/pixel-format/yuv-yuy2/
 	FormatYUY2 = "YUY2"
+	// FormatYUYV https://www.fourcc.org/pixel-format/yuv-yuy2/
+	FormatYUYV = "YUYV"
 	// FormatUYVY https://www.fourcc.org/pixel-format/yuv-uyvy/
 	FormatUYVY = "UYVY"
 
@@ -30,13 +32,12 @@ const (
 	FormatZ16 = "Z16"
 )
 
-const FormatYUYV = FormatYUY2
-
 var decoderMap = map[Format]decoderFunc{
 	FormatI420:  decodeI420,
 	FormatNV21:  decodeNV21,
 	FormatNV12:  decodeNV12,
 	FormatYUY2:  decodeYUY2,
+	FormatYUYV:  decodeYUY2,
 	FormatUYVY:  decodeUYVY,
 	FormatMJPEG: decodeMJPEG,
 	FormatZ16:   decodeZ16,


### PR DESCRIPTION
#### Description
Add YUYV to supported video formats; used to be implicitly supported under YUY2. That meant the user had to know to ask for YUY2 decoding when using a YUYV device; this PR allows the user to specify YUYV instead.
