### PR TITLE
Added Name in driver.Info to Microphone driver

### DIFF
--- a/pkg/driver/microphone/microphone.go
+++ b/pkg/driver/microphone/microphone.go
@@ -68,6 +68,7 @@ func Initialize() {
 				Label:      device.ID.String(),
 				DeviceType: driver.Microphone,
 				Priority:   priority,
+				Name:       info.Name(),
 			})
 		}
 	}


### PR DESCRIPTION
A tiny change to the Initialize function in the Microphone driver ensuring that the device name is included in the driver.Info struct.