### PR TITLE
Add props even if framerate is not supported by the driver

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -316,7 +316,20 @@ func (c *camera) Properties() []prop.Media {
 			}
 
 			if frameSize.StepWidth == 0 || frameSize.StepHeight == 0 {
-				for _, framerate := range c.cam.GetSupportedFramerates(format, frameSize.MinWidth, frameSize.MinHeight) {
+				framerates := c.cam.GetSupportedFramerates(format, uint32(frameSize.MaxWidth), uint32(frameSize.MaxHeight))
+				// If the camera doesn't support framerate, we just add the resolution and format
+				if len(framerates) == 0 {
+					properties = append(properties, prop.Media{
+						Video: prop.Video{
+							Width:       int(frameSize.MaxWidth),
+							Height:      int(frameSize.MaxHeight),
+							FrameFormat: supportedFormat,
+						},
+					})
+					continue
+				}
+
+				for _, framerate := range framerates {
 					for _, fps := range enumFramerate(framerate) {
 						properties = append(properties, prop.Media{
 							Video: prop.Video{
@@ -346,7 +359,20 @@ func (c *camera) Properties() []prop.Media {
 						continue
 					}
 
-					for _, framerate := range c.cam.GetSupportedFramerates(format, uint32(width), uint32(height)) {
+					framerates := c.cam.GetSupportedFramerates(format, uint32(width), uint32(height))
+					// If the camera doesn't support framerate, we just add the resolution and format
+					if len(framerates) == 0 {
+						properties = append(properties, prop.Media{
+							Video: prop.Video{
+								Width:       width,
+								Height:      height,
+								FrameFormat: supportedFormat,
+							},
+						})
+						continue
+					}
+
+					for _, framerate := range framerates {
 						for _, fps := range enumFramerate(framerate) {
 							properties = append(properties, prop.Media{
 								Video: prop.Video{

--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -360,7 +360,6 @@ func (c *camera) Properties() []prop.Media {
 					}
 
 					framerates := c.cam.GetSupportedFramerates(format, uint32(width), uint32(height))
-					// If the camera doesn't support framerate, we just add the resolution and format
 					if len(framerates) == 0 {
 						properties = append(properties, prop.Media{
 							Video: prop.Video{


### PR DESCRIPTION
#### Description

This PR fixes an issue where properties are skipped if framerate querying is not supported by the driver. To fix this we simply add width, height, and format if `GetSupportedFramerates` errors or returns an empty list.
