### PR TITLE
Add manager clearing mechanism for linux cams

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -86,6 +86,12 @@ func init() {
 
 // Initialize finds and registers camera devices. This is part of an experimental API.
 func Initialize() {
+	// Clear all registered camera devices to prevent duplicates.
+	// If first initalize call, this will be a noop.
+	manager := driver.GetManager()
+	for _, d := range manager.Query(driver.FilterVideoRecorder()) {
+		manager.Delete(d.ID())
+	}
 	discovered := make(map[string]struct{})
 	discover(discovered, "/dev/v4l/by-id/*")
 	discover(discovered, "/dev/v4l/by-path/*")

--- a/pkg/driver/manager.go
+++ b/pkg/driver/manager.go
@@ -92,3 +92,10 @@ func (m *Manager) Query(f FilterFn) []Driver {
 
 	return results
 }
+
+// Delete deletes a driver from manager given its ID
+func (m *Manager) Delete(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.drivers, id)
+}


### PR DESCRIPTION
#### Description
Currently, there is a bug in the `Initialize()` fn in `camera_linux.go` where the full driver list is appended causing the manager to fill up with duplicates. This is due to generating a new uuid on the fly for each driver record.

This issue does not occur id `camera_darwin.go` because the id is taken from `avfoundation` and is deterministic/unique for each driver.

####  Solution
Clear all video drivers during the `Initialize` call to prevent duplicates.
