### PR TITLE
Update malgo to v0.11.11-0.20231225022531-dd505cb7efd5 for a macOS microphone fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/blackjack/webcam v0.5.0
-	github.com/gen2brain/malgo v0.11.10
+	github.com/gen2brain/malgo v0.11.21
 	github.com/google/uuid v1.5.0
 	github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237
 	github.com/pion/interceptor v0.1.25

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gen2brain/malgo v0.11.10 h1:u41QchDBS7Z2rwEVPu7uycK6HA8IyzKoUOhLU7IvYW4=
-github.com/gen2brain/malgo v0.11.10/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
+github.com/gen2brain/malgo v0.11.21 h1:qsS4Dh6zhZgmvAW5CtKRxDjQzHbc2NJlBG9eE0tgS8w=
+github.com/gen2brain/malgo v0.11.21/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/gen2brain/shm v0.0.0-20230802011745-f2460f5984f7 h1:VLEKvjGJYAMCXw0/32r9io61tEXnMWDRxMk+peyRVFc=
 github.com/gen2brain/shm v0.0.0-20230802011745-f2460f5984f7/go.mod h1:uF6rMu/1nvu+5DpiRLwusA6xB8zlkNoGzKn8lmYONUo=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=

--- a/pkg/driver/microphone/microphone.go
+++ b/pkg/driver/microphone/microphone.go
@@ -213,6 +213,7 @@ func (m *microphone) Properties() []prop.Media {
 			},
 		}
 
+		supportedFormat := true
 		switch malgo.FormatType(format.Format) {
 		case malgo.FormatF32:
 			supportedProp.SampleSize = 4
@@ -220,8 +221,14 @@ func (m *microphone) Properties() []prop.Media {
 		case malgo.FormatS16:
 			supportedProp.SampleSize = 2
 			supportedProp.IsFloat = false
+		default:
+			supportedFormat = false
 		}
 
+		if !supportedFormat {
+			logger.Warnf("format '%s' not supported", format.Format)
+			continue
+		}
 		supportedProps = append(supportedProps, supportedProp)
 		// }
 	}


### PR DESCRIPTION
- Also log when we do not support a malgo format (e.g. the iota value)