### PR TITLE
Add webcam close to linux camera discover

### DIFF
--- a/pkg/driver/camera/camera_linux.go
+++ b/pkg/driver/camera/camera_linux.go
@@ -125,6 +125,7 @@ func discover(discovered map[string]struct{}, pattern string) {
 
 		var name, busInfo string
 		if webcamCam, err := webcam.Open(cam.path); err == nil {
+			defer webcamCam.Close()
 			name, _ = webcamCam.GetName()
 			busInfo, _ = webcamCam.GetBusInfo()
 		}


### PR DESCRIPTION
#### Description

This PR fixes an issue with dangling open files from Linux camera Initialize/discover calls (we are missing a webcam close).