### PR TITLE
Bump webcam dependency

### DIFF
--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,6 @@
 github.com/blackjack/webcam v0.6.0 h1:ovvUNsIQZVfJZl6V2FcvFLFH62/Xx5zLwybKwEy3ZLw=
 github.com/blackjack/webcam v0.6.0/go.mod h1:zs+RkUZzqpFPHPiwBZ6U5B34ZXXe9i+SiHLKnnukJuI=
+github.com/blackjack/webcam v0.6.1/go.mod h1:zs+RkUZzqpFPHPiwBZ6U5B34ZXXe9i+SiHLKnnukJuI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pion/mediadevices
 go 1.19
 
 require (
-	github.com/blackjack/webcam v0.6.0
+	github.com/blackjack/webcam v0.6.1
 	github.com/gen2brain/malgo v0.11.21
 	github.com/google/uuid v1.6.0
 	github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blackjack/webcam v0.6.0 h1:ovvUNsIQZVfJZl6V2FcvFLFH62/Xx5zLwybKwEy3ZLw=
-github.com/blackjack/webcam v0.6.0/go.mod h1:zs+RkUZzqpFPHPiwBZ6U5B34ZXXe9i+SiHLKnnukJuI=
+github.com/blackjack/webcam v0.6.1 h1:K0T6Q0zto23U99gNAa5q/hFoye6uGcKr2aE6hFoxVoE=
+github.com/blackjack/webcam v0.6.1/go.mod h1:zs+RkUZzqpFPHPiwBZ6U5B34ZXXe9i+SiHLKnnukJuI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
#### Description

Simple webcam bump to `0.6.1` -- fixes issue with mmap flags causing streams to fail for some Linux drivers.
See webcam commit [here](https://github.com/blackjack/webcam/commit/15347780752e4f6e9767d4e8b15a60038dc27f85).