### PR TITLE
[vpx_codec_encode] prevent overflow in duration/deadline

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,7 +10,7 @@ require (
 
 require (
 	github.com/blackjack/webcam v0.6.1 // indirect
-	github.com/gen2brain/malgo v0.11.22 // indirect
+	github.com/gen2brain/malgo v0.11.23 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pion/datachannel v1.5.9 // indirect
 	github.com/pion/dtls/v3 v3.0.4 // indirect
@@ -29,7 +29,7 @@ require (
 	github.com/pion/turn/v4 v4.0.0 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/crypto v0.29.0 // indirect
-	golang.org/x/image v0.21.0 // indirect
+	golang.org/x/image v0.23.0 // indirect
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -9,6 +9,7 @@ github.com/esimov/pigo v1.4.6/go.mod h1:uqj9Y3+3IRYhFK071rxz1QYq0ePhA6+R9jrUZavi
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/gen2brain/malgo v0.11.22 h1:fRtTbzVI9CDWnfEJGo/GxKxN7pXtCb0NsAeUVUjZk9U=
 github.com/gen2brain/malgo v0.11.22/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
+github.com/gen2brain/malgo v0.11.23/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -64,6 +65,7 @@ golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/image v0.0.0-20200927104501-e162460cd6b5/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.21.0 h1:c5qV36ajHpdj4Qi0GnE0jUc/yuo33OLFaa0d+crTD5s=
 golang.org/x/image v0.21.0/go.mod h1:vUbsLavqK/W303ZroQQVKQ+Af3Yl6Uz1Ppu5J/cLz78=
+golang.org/x/image v0.23.0/go.mod h1:wJJBTdLfCCf3tiHa1fNxpZmUI4mmoZvwMCPP0ddoNKY=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
 golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -69,8 +69,8 @@ type encoder struct {
 	cfg             *C.vpx_codec_enc_cfg_t
 	r               video.Reader
 	frameIndex      int
-	tStart          int
-	tLastFrame      int
+	tStart          int64
+	tLastFrame      int64
 	frame           []byte
 	deadline        int
 	requireKeyFrame bool
@@ -198,7 +198,7 @@ func newEncoder(r video.Reader, p prop.Media, params Params, codecIface *C.vpx_c
 	); ec != 0 {
 		return nil, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
 	}
-	t0 := time.Now().Nanosecond() / 1000000
+	t0 := time.Now().UnixMilli()
 	return &encoder{
 		r:          video.ToI420(r),
 		codec:      codec,
@@ -233,7 +233,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	e.raw.stride[1] = C.int(yuvImg.CStride)
 	e.raw.stride[2] = C.int(yuvImg.CStride)
 
-	t := time.Now().Nanosecond() / 1000000
+	t := time.Now().UnixMilli()
 
 	if e.cfg.g_w != C.uint(width) || e.cfg.g_h != C.uint(height) {
 		e.cfg.g_w, e.cfg.g_h = C.uint(width), C.uint(height)


### PR DESCRIPTION
[latest libvpx release added extended validation for duration](https://github.com/webmproject/libvpx/commit/7fb8ceccf92c35cd5131b05c0502916715ebc76b)
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/b4f1c7b8-4658-48de-9c6b-f16818338d37" />

