### PR TITLE
Clear found drivers in manager on each initialize call (Darwin)

### DIFF
--- a/pkg/driver/camera/camera_darwin.go
+++ b/pkg/driver/camera/camera_darwin.go
@@ -22,6 +22,13 @@ func init() {
 
 // Initialize finds and registers camera devices. This is part of an experimental API.
 func Initialize() {
+	// Clear all registered camera devices to prevent duplicates.
+	// If first initalize call, this will be a noop.
+	manager := driver.GetManager()
+	for _, d := range manager.Query(driver.FilterVideoRecorder()) {
+		manager.Delete(d.ID())
+	}
+
 	devices, err := avfoundation.Devices(avfoundation.Video)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
#### Description
In camera_linux.go, we clear all registered camera devices to prevent duplicates each time `Initialize` is called. We should do the same for Darwin