### PR TITLE
Fix the VPX encoder is not properly handling the frame timestamp

### DIFF
--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -69,8 +69,8 @@ type encoder struct {
 	cfg             *C.vpx_codec_enc_cfg_t
 	r               video.Reader
 	frameIndex      int
-	tStart          int
-	tLastFrame      int
+	tStart          time.Time
+	tLastFrame      time.Time
 	frame           []byte
 	deadline        int
 	requireKeyFrame bool
@@ -198,7 +198,7 @@ func newEncoder(r video.Reader, p prop.Media, params Params, codecIface *C.vpx_c
 	); ec != 0 {
 		return nil, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
 	}
-	t0 := time.Now().Nanosecond() / 1000000
+	t0 := time.Now()
 	return &encoder{
 		r:          video.ToI420(r),
 		codec:      codec,
@@ -233,7 +233,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	e.raw.stride[1] = C.int(yuvImg.CStride)
 	e.raw.stride[2] = C.int(yuvImg.CStride)
 
-	t := time.Now().Nanosecond() / 1000000
+	t := time.Now()
 
 	if e.cfg.g_w != C.uint(width) || e.cfg.g_h != C.uint(height) {
 		e.cfg.g_w, e.cfg.g_h = C.uint(width), C.uint(height)
@@ -252,7 +252,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 		e.raw.d_w, e.raw.d_h = C.uint(width), C.uint(height)
 	}
 
-	duration := t - e.tLastFrame
+	duration := t.Sub(e.tLastFrame).Nanoseconds() / 1000000
 	// VPX doesn't allow 0 duration. If 0 is given, vpx_codec_encode will fail with VPX_CODEC_INVALID_PARAM.
 	// 0 duration is possible because mediadevices first gets the frame meta data by reading from the source,
 	// and consequently the codec will read the first frame from the buffer. This means the first frame won't
@@ -267,7 +267,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	}
 	if ec := C.encode_wrapper(
 		e.codec, e.raw,
-		C.long(t-e.tStart), C.ulong(duration), C.long(flags), C.ulong(e.deadline),
+		C.long(t.Sub(e.tStart).Nanoseconds()/1000000), C.ulong(duration), C.long(flags), C.ulong(e.deadline),
 		(*C.uchar)(&yuvImg.Y[0]), (*C.uchar)(&yuvImg.Cb[0]), (*C.uchar)(&yuvImg.Cr[0]),
 	); ec != C.VPX_CODEC_OK {
 		return nil, func() {}, fmt.Errorf("vpx_codec_encode failed (%d)", ec)

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -252,7 +252,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 		e.raw.d_w, e.raw.d_h = C.uint(width), C.uint(height)
 	}
 
-	duration := t.Sub(e.tLastFrame).Nanoseconds() / 1000000
+	duration := t.Sub(e.tLastFrame).Microseconds()
 	// VPX doesn't allow 0 duration. If 0 is given, vpx_codec_encode will fail with VPX_CODEC_INVALID_PARAM.
 	// 0 duration is possible because mediadevices first gets the frame meta data by reading from the source,
 	// and consequently the codec will read the first frame from the buffer. This means the first frame won't
@@ -267,7 +267,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	}
 	if ec := C.encode_wrapper(
 		e.codec, e.raw,
-		C.long(t.Sub(e.tStart).Nanoseconds()/1000000), C.ulong(duration), C.long(flags), C.ulong(e.deadline),
+		C.long(t.Sub(e.tStart).Microseconds()), C.ulong(duration), C.long(flags), C.ulong(e.deadline),
 		(*C.uchar)(&yuvImg.Y[0]), (*C.uchar)(&yuvImg.Cb[0]), (*C.uchar)(&yuvImg.Cr[0]),
 	); ec != C.VPX_CODEC_OK {
 		return nil, func() {}, fmt.Errorf("vpx_codec_encode failed (%d)", ec)


### PR DESCRIPTION
There is an issue with VPX encoder that using `time.Now().Nanosecond() / 1000000` as the timestamp marker and make the timestamp is not monotonic and there is a potential issue the frame duration become negative and make the encoding failed.

Check the new test included in this PR to reproduce the issue.

Updated:
I just saw this issue seems similar to #603 I can close this one and merge that one if needed.
