### PR TITLE
Add EncoderController() codec.EncoderController in Track interface.

### DIFF
--- a/mediastream_test.go
+++ b/mediastream_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -59,6 +60,10 @@ func (track *mockMediaStreamTrack) NewEncodedReader(codecName string) (EncodedRe
 
 func (track *mockMediaStreamTrack) NewEncodedIOReader(codecName string) (io.ReadCloser, error) {
 	return nil, nil
+}
+
+func (track *mockMediaStreamTrack) EncoderController() codec.EncoderController {
+	return nil
 }
 
 func TestMediaStreamFilters(t *testing.T) {

--- a/track.go
+++ b/track.go
@@ -77,6 +77,8 @@ type Track interface {
 	NewEncodedReader(codecName string) (EncodedReadCloser, error)
 	// NewEncodedReader creates a new Go standard io.ReadCloser that reads the encoded data in codecName format
 	NewEncodedIOReader(codecName string) (io.ReadCloser, error)
+	// EncoderController returns the encoder controller if the track has one, else returns nil
+	EncoderController() codec.EncoderController
 }
 
 type baseTrack struct {


### PR DESCRIPTION
In previous pr #612, method EncoderController is added on VideoTrack and AudioTrack.

This PR adds this method in Track interface as well.