### PR TITLE
fix track.unbind panic

### DIFF
--- a/track.go
+++ b/track.go
@@ -203,8 +203,10 @@ func (track *baseTrack) bind(ctx webrtc.TrackLocalContext, specializedTrack Trac
 			encodedReader.Close()
 
 			// When there's another call to unbind, it won't block since we remove the current ctx from active connections
-			track.removeActivePeerConnection(ctx.ID())
-			close(signalCh)
+			signalCh := track.removeActivePeerConnection(ctx.ID())
+			if signalCh != nil {
+				close(signalCh)
+			}
 			if doneCh != nil {
 				close(doneCh)
 			}


### PR DESCRIPTION
Fixes: #633

Here the signalCh could have been closed by another goroutine, we should
use returned signalCh from `track.removeActivePeerConnection()` to close
the channel.

Actually, I don't know why we need to close the signalCh, we're using it
to send over the doneCh, why ever close it?
