### PR TITLE
Try to fix libvpx not found during ci test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           which brew
+          brew update
           brew install \
             pkg-config \
             opus \


### PR DESCRIPTION
Try to fix the following ci build error

https://github.com/pion/mediadevices/actions/runs/15627214233/job/44023636984

on macOS

```
ld: warning: search path '/opt/homebrew/Cellar/libvpx/1.15.1/lib' not found
ld: library 'vpx' not found
```

The libvpx installed is 1.15.2, but during build the compiler tries to find 1.15.1