### PR TITLE
[VPX] Add vp8 decoder and dynamic vp8 encoding

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -177,9 +177,12 @@ type BitRateController interface {
 	// SetBitRate sets current target bitrate, lower bitrate means smaller data will be transmitted
 	// but this also means that the quality will also be lower.
 	SetBitRate(int) error
-	// VP8DynamicRateControl is a helper function to dynamically adjust the bitrate of the VP8 codec
-	// based on the current and target bitrate, underlying is dynamic QP adjustment.
-	VP8DynamicRateControl(int, int) error
+}
+
+type QPController interface {
+	EncoderController
+	// DynamicQPControl adjusts the QP of the encoder based on the current and target bitrate
+	DynamicQPControl(int, int) error
 }
 
 // BaseParams represents an codec's encoding properties

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -177,6 +177,9 @@ type BitRateController interface {
 	// SetBitRate sets current target bitrate, lower bitrate means smaller data will be transmitted
 	// but this also means that the quality will also be lower.
 	SetBitRate(int) error
+	// VP8DynamicRateControl is a helper function to dynamically adjust the bitrate of the VP8 codec
+	// based on the current and target bitrate, underlying is dynamic QP adjustment.
+	VP8DynamicRateControl(int, int) error
 }
 
 // BaseParams represents an codec's encoding properties

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -327,7 +327,7 @@ func (e *encoder) SetBitRate(bitrate int) error {
 	return nil
 }
 
-func (e *encoder) VP8DynamicRateControl(currentBitrate int, targetBitrate int) error {
+func (e *encoder) DynamicQPControl(currentBitrate int, targetBitrate int) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	bitrateDiff := math.Abs(float64(currentBitrate - targetBitrate))

--- a/pkg/codec/vpx/vpx_decoder.go
+++ b/pkg/codec/vpx/vpx_decoder.go
@@ -1,0 +1,107 @@
+package vpx
+
+/*
+#cgo pkg-config: vpx
+#include <stdlib.h>
+#include <stdint.h>
+#include <vpx/vpx_decoder.h>
+#include <vpx/vpx_codec.h>
+#include <vpx/vpx_image.h>
+#include <vpx/vp8dx.h>
+
+vpx_codec_iface_t *ifaceVP8Decoder() {
+   return vpx_codec_vp8_dx();
+}
+vpx_codec_iface_t *ifaceVP9Decoder() {
+   return vpx_codec_vp9_dx();
+}
+
+// Allocates a new decoder context
+vpx_codec_ctx_t* newDecoderCtx() {
+    return (vpx_codec_ctx_t*)malloc(sizeof(vpx_codec_ctx_t));
+}
+
+// Initializes the decoder
+vpx_codec_err_t decoderInit(vpx_codec_ctx_t* ctx, vpx_codec_iface_t* iface) {
+    return vpx_codec_dec_init_ver(ctx, iface, NULL, 0, VPX_DECODER_ABI_VERSION);
+}
+
+// Decodes an encoded frame
+vpx_codec_err_t decodeFrame(vpx_codec_ctx_t* ctx, const uint8_t* data, unsigned int data_sz) {
+    return vpx_codec_decode(ctx, data, data_sz, NULL, 0);
+}
+
+// Creates an iterator
+vpx_codec_iter_t* newIter() {
+    return (vpx_codec_iter_t*)malloc(sizeof(vpx_codec_iter_t));
+}
+
+// Returns the next decoded frame
+vpx_image_t* getFrame(vpx_codec_ctx_t* ctx, vpx_codec_iter_t* iter) {
+    return vpx_codec_get_frame(ctx, iter);
+}
+
+// Frees a decoder context
+void freeDecoderCtx(vpx_codec_ctx_t* ctx) {
+    vpx_codec_destroy(ctx);
+    free(ctx);
+}
+
+*/
+import "C"
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pion/mediadevices/pkg/prop"
+)
+
+type Decoder struct {
+	codec      *C.vpx_codec_ctx_t
+	raw        *C.vpx_image_t
+	cfg        *C.vpx_codec_dec_cfg_t
+	frameIndex int
+	tStart     time.Time
+	tLastFrame time.Time
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func NewDecoder(p prop.Media) (Decoder, error) {
+	cfg := &C.vpx_codec_dec_cfg_t{}
+	cfg.threads = 1
+	cfg.w = C.uint(p.Width)
+	cfg.h = C.uint(p.Height)
+
+	codec := C.newDecoderCtx()
+	if C.decoderInit(codec, C.ifaceVP8Decoder()) != C.VPX_CODEC_OK {
+		return Decoder{}, fmt.Errorf("vpx_codec_dec_init failed")
+	}
+
+	return Decoder{
+		codec: codec,
+		cfg:   cfg,
+	}, nil
+}
+
+func (d *Decoder) Decode(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	status := C.decodeFrame(d.codec, (*C.uint8_t)(&data[0]), C.uint(len(data)))
+	if status != C.VPX_CODEC_OK {
+		fmt.Println("Decode failed", status)
+		panic("Decode failed")
+	}
+}
+
+func (d *Decoder) GetFrame() *C.vpx_image_t {
+	iter := C.newIter()
+	return C.getFrame(d.codec, iter)
+}
+
+func (d *Decoder) FreeDecoderCtx() {
+	C.freeDecoderCtx(d.codec)
+}

--- a/pkg/codec/vpx/vpx_test.go
+++ b/pkg/codec/vpx/vpx_test.go
@@ -364,7 +364,7 @@ func TestEncoderFrameMonotonic(t *testing.T) {
 	}
 }
 
-func TestVP8DynamicRateControl(t *testing.T) {
+func TestVP8DynamicQPControl(t *testing.T) {
 	t.Run("VP8", func(t *testing.T) {
 		p, err := NewVP8Params()
 		if err != nil {
@@ -413,7 +413,7 @@ func TestVP8DynamicRateControl(t *testing.T) {
 		targetBitrate := 300
 		for i := 0; i < totalFrames; i++ {
 			r.Controller().(codec.KeyFrameController).ForceKeyFrame()
-			r.Controller().(codec.BitRateController).VP8DynamicRateControl(currentBitrate, targetBitrate)
+			r.Controller().(codec.QPController).DynamicQPControl(currentBitrate, targetBitrate)
 			data, rel, err := r.Read()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
#### Description
This PR made two changes with corresponding tests:
1. Add vpx (vp8) decoder that is able to decode the frames encoded by vp8 encoder
2. Add dynamic rate control, given the estimated or target bitrate, adjust the QP value to make the encoder adjust to the network condition
