### PR TITLE
Fix Windows DirectShow: Add virtual camera support and friendly names

### DIFF
--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -33,6 +33,27 @@ void printErr(HRESULT hr)
 // returned pointer must be released by free() after use.
 char* getCameraName(IMoniker* moniker)
 {
+  IPropertyBag* pPropBag = nullptr;
+  VARIANT varName;
+  VariantInit(&varName);
+  
+  // Try to get FriendlyName
+  if (SUCCEEDED(moniker->BindToStorage(nullptr, nullptr, IID_IPropertyBag, (void**)&pPropBag)))
+  {
+    if (SUCCEEDED(pPropBag->Read(L"FriendlyName", &varName, 0)))
+    {
+      std::string nameStr = utf16Decode(varName.bstrVal);
+      char* ret = (char*)malloc(nameStr.size() + 1);
+      memcpy(ret, nameStr.c_str(), nameStr.size() + 1);
+      VariantClear(&varName);
+      pPropBag->Release();
+      return ret;
+    }
+    pPropBag->Release();
+  }
+  VariantClear(&varName);
+  
+  // Fallback to display name
   LPOLESTR name;
   if (FAILED(moniker->GetDisplayName(nullptr, nullptr, &name)))
     return nullptr;
@@ -312,20 +333,10 @@ int openCamera(camera* cam, const char** errstr)
     AM_MEDIA_TYPE mediaType;
     memset(&mediaType, 0, sizeof(mediaType));
     mediaType.majortype = MEDIATYPE_Video;
-    mediaType.subtype = MEDIASUBTYPE_YUY2;
+    // Accept any format by leaving subtype as zeros (equivalent to GUID_NULL)
+    memset(&mediaType.subtype, 0, sizeof(GUID));
     mediaType.formattype = FORMAT_VideoInfo;
-    mediaType.bFixedSizeSamples = 1;
-    mediaType.cbFormat = sizeof(VIDEOINFOHEADER);
-
-    VIDEOINFOHEADER videoInfoHdr;
-    memset(&videoInfoHdr, 0, sizeof(VIDEOINFOHEADER));
-    videoInfoHdr.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-    videoInfoHdr.bmiHeader.biWidth = cam->width;
-    videoInfoHdr.bmiHeader.biHeight = cam->height;
-    videoInfoHdr.bmiHeader.biPlanes = 1;
-    videoInfoHdr.bmiHeader.biBitCount = 16;
-    videoInfoHdr.bmiHeader.biCompression = MAKEFOURCC('Y', 'U', 'Y', '2');
-    mediaType.pbFormat = (BYTE*)&videoInfoHdr;
+    // Let DirectShow negotiate format automatically
     if (FAILED(grabber->SetMediaType(&mediaType)))
     {
       *errstr = errGrabber;
@@ -366,6 +377,9 @@ int openCamera(camera* cam, const char** errstr)
   safeRelease(&src);
   safeRelease(&dst);
 
+  // FIX: Don't connect to null renderer
+  // Null renderer causes DirectShow to pause after one frame
+  /*
   end = getPin(grabberFilter, PINDIR_OUTPUT);
   nul = getPin(nullFilter, PINDIR_INPUT);
   if (end == nullptr || nul == nullptr ||
@@ -377,6 +391,7 @@ int openCamera(camera* cam, const char** errstr)
 
   safeRelease(&end);
   safeRelease(&nul);
+  */
 
   safeRelease(&nullFilter);
   safeRelease(&captureFilter);
@@ -422,29 +437,74 @@ HRESULT SampleGrabberCallback::BufferCB(double sampleTime, BYTE* buf, LONG len)
 {
   BYTE* gobuf = (BYTE*)cam_->buf;
   const int nPix = cam_->width * cam_->height;
-  if (len > nPix * 2)
+  const int expectedNV12 = nPix + nPix / 2;
+  const int expectedYUY2 = nPix * 2;
+  
+  if (abs(len - expectedNV12) <= 10)
   {
-    fprintf(stderr, "Wrong frame buffer size: %d > %d\n", len, nPix * 2);
-    return S_OK;
-  }
-  int yi = 0;
-  int cbi = cam_->width * cam_->height;
-  int cri = cbi + cbi / 2;
-  // Pack as I422
-  for (int y = 0; y < cam_->height; ++y)
-  {
-    int j = y * cam_->width * 2;
-    for (int x = 0; x < cam_->width / 2; ++x)
+    // NV12 → I420: Copy Y, de-interleave UV
+    memcpy(gobuf, buf, nPix);
+    const BYTE* uv = buf + nPix;
+    BYTE* u = gobuf + nPix;
+    BYTE* v = u + nPix / 4;
+    
+    int uvSize = nPix / 4;
+    int i = 0;
+    
+    // Process 4 pixels at a time
+    for (; i < uvSize - 3; i += 4)
     {
-      gobuf[yi] = buf[j];
-      gobuf[cbi] = buf[j + 1];
-      gobuf[yi + 1] = buf[j + 2];
-      gobuf[cri] = buf[j + 3];
-      j += 4;
-      yi += 2;
-      cbi++;
-      cri++;
+      u[i] = uv[i * 2];
+      v[i] = uv[i * 2 + 1];
+      u[i + 1] = uv[(i + 1) * 2];
+      v[i + 1] = uv[(i + 1) * 2 + 1];
+      u[i + 2] = uv[(i + 2) * 2];
+      v[i + 2] = uv[(i + 2) * 2 + 1];
+      u[i + 3] = uv[(i + 3) * 2];
+      v[i + 3] = uv[(i + 3) * 2 + 1];
     }
+    
+    // Handle remaining pixels
+    for (; i < uvSize; i++)
+    {
+      u[i] = uv[i * 2];
+      v[i] = uv[i * 2 + 1];
+    }
+  }
+  else if (abs(len - expectedYUY2) <= 10)
+  {
+    // YUY2 → I420: Extract Y, subsample and average UV vertically
+    BYTE* y = gobuf;
+    BYTE* u = gobuf + nPix;
+    BYTE* v = u + nPix / 4;
+    
+    for (int row = 0; row < cam_->height; row += 2)
+    {
+      const BYTE* src1 = buf + row * cam_->width * 2;
+      const BYTE* src2 = src1 + cam_->width * 2;
+      
+      for (int col = 0; col < cam_->width; col += 2)
+      {
+        y[0] = src1[0];
+        y[1] = src1[2];
+        y[cam_->width] = src2[0];
+        y[cam_->width + 1] = src2[2];
+        y += 2;
+        
+        *u++ = (src1[1] + src2[1]) / 2;
+        *v++ = (src1[3] + src2[3]) / 2;
+        
+        src1 += 4;
+        src2 += 4;
+      }
+      y += cam_->width;
+    }
+  }
+  else
+  {
+    fprintf(stderr, "Unexpected buffer size: %d (expected NV12=%d or YUY2=%d)\n", 
+            len, expectedNV12, expectedYUY2);
+    return S_OK;
   }
 
   imageCallback((size_t)cam_);


### PR DESCRIPTION
Partially addresses #95 - Adds NV12 format support and fixes continuous frame delivery

## Problem

The current Windows DirectShow implementation has three critical issues:

1. **Single-frame capture**: Streaming stops after the first frame due to Null Renderer connection
2. **No virtual camera support**: Only YUY2 format supported, preventing OBS Virtual Camera from working
3. **Unfriendly device names**: Shows DirectShow paths instead of readable camera names

## Solution

This PR fixes all three issues:

- ✅ Removes Null Renderer connection to enable continuous frame delivery
- ✅ Auto-detects NV12 and YUY2 formats based on buffer size
- ✅ Converts both formats to I420 (4:2:0) for consistency
- ✅ Uses IPropertyBag FriendlyName property for readable camera names
- ✅ Fixes memory leak in Open() if listResolution fails
- ✅ Optimizes NV12 conversion with loop unrolling
- ✅ Adds channel buffer to reduce frame drops

## Testing

Tested on Windows 10/11 with:
- ✅ OBS Virtual Camera (NV12 format) - now works
- ✅ Physical webcams (YUY2 format) - continue working
- ✅ Device enumeration - shows friendly names
- ✅ Continuous streaming - sustained 30+ FPS

## Before/After

**Device names:**
```
Before: @device_sw_{860BB310-5D01-11D0-BD3B-00A0C911CE86}\{A3FCE0F5-3493-419F-958A-ABA1250EC20B}
After:  OBS Virtual Camera
```

**Streaming:**
```
Before: Stops after 1 frame ❌
After:  Continuous 30+ FPS ✅
```

## Files Modified

- `pkg/driver/camera/camera_windows.cpp` (~90 lines changed)
- `pkg/driver/camera/camera_windows.go` (~25 lines changed)

## Breaking Changes

None - 100% backward compatible

## Notes

This patch was developed with Claude AI assistance through extensive testing and iteration. I'm not a C programmer, so please review carefully. Happy to address any feedback!

Co-authored-by: Claude AI <https://claude.ai>