### PR TITLE
(3/3) Fix concurrency webcam windows

### DIFF
--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -5,6 +5,7 @@
 #include <dvdmedia.h>
 #include <qedit.h>
 #include <mmsystem.h>
+#include <wmcodecdsp.h>
 
 #include "camera_windows.hpp"
 #include "_cgo_export.h"

--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -52,6 +52,27 @@ void printErr(HRESULT hr)
 // returned pointer must be released by free() after use.
 char* getCameraName(IMoniker* moniker)
 {
+  // Try to get the friendly name via IPropertyBag.
+  IPropertyBag* propBag = nullptr;
+  if (SUCCEEDED(moniker->BindToStorage(0, 0, IID_IPropertyBag, (void**)&propBag)))
+  {
+    VARIANT varName;
+    VariantInit(&varName);
+    if (SUCCEEDED(propBag->Read(L"FriendlyName", &varName, 0)))
+    {
+      std::string nameStr = utf16Decode(varName.bstrVal);
+      VariantClear(&varName);
+      propBag->Release();
+
+      char* ret = (char*)malloc(nameStr.size() + 1);
+      memcpy(ret, nameStr.c_str(), nameStr.size() + 1);
+      return ret;
+    }
+    VariantClear(&varName);
+    propBag->Release();
+  }
+
+  // Fallback to display name.
   LPOLESTR name;
   if (FAILED(moniker->GetDisplayName(nullptr, nullptr, &name)))
     return nullptr;

--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -253,7 +253,6 @@ int listResolution(camera* cam, const char** errstr)
   ICaptureGraphBuilder2* captureGraph = nullptr;
   IAMStreamConfig* config = nullptr;
   IPin* src = nullptr;
-  LPOLESTR name;
 
   if (!selectCamera(cam, &moniker, errstr))
   {
@@ -324,6 +323,7 @@ int listResolution(camera* cam, const char** errstr)
       cam->props[iProp].fcc = mediaType->subtype.Data1;
       freeMediaType(mediaType);
       iProp++;
+      freeMediaType(mediaType);
     }
     cam->numProps = iProp;
   }
@@ -623,7 +623,7 @@ void freeCamera(camera* cam)
 
   if (cam->props)
   {
-    delete cam->props;
+    delete[] cam->props;
     cam->props = nullptr;
   }
 }

--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -52,27 +52,6 @@ void printErr(HRESULT hr)
 // returned pointer must be released by free() after use.
 char* getCameraName(IMoniker* moniker)
 {
-  // Try to get the friendly name via IPropertyBag.
-  IPropertyBag* propBag = nullptr;
-  if (SUCCEEDED(moniker->BindToStorage(0, 0, IID_IPropertyBag, (void**)&propBag)))
-  {
-    VARIANT varName;
-    VariantInit(&varName);
-    if (SUCCEEDED(propBag->Read(L"FriendlyName", &varName, 0)))
-    {
-      std::string nameStr = utf16Decode(varName.bstrVal);
-      VariantClear(&varName);
-      propBag->Release();
-
-      char* ret = (char*)malloc(nameStr.size() + 1);
-      memcpy(ret, nameStr.c_str(), nameStr.size() + 1);
-      return ret;
-    }
-    VariantClear(&varName);
-    propBag->Release();
-  }
-
-  // Fallback to display name.
   LPOLESTR name;
   if (FAILED(moniker->GetDisplayName(nullptr, nullptr, &name)))
     return nullptr;

--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -323,7 +323,6 @@ int listResolution(camera* cam, const char** errstr)
       cam->props[iProp].fcc = mediaType->subtype.Data1;
       freeMediaType(mediaType);
       iProp++;
-      freeMediaType(mediaType);
     }
     cam->numProps = iProp;
   }

--- a/pkg/driver/camera/camera_windows.cpp
+++ b/pkg/driver/camera/camera_windows.cpp
@@ -5,7 +5,6 @@
 #include <dvdmedia.h>
 #include <qedit.h>
 #include <mmsystem.h>
-#include <wmcodecdsp.h>
 
 #include "camera_windows.hpp"
 #include "_cgo_export.h"

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -83,6 +83,10 @@ func DestroyObserver() error {
 }
 
 func (c *camera) Open() error {
+	// COM is per-thread on Windows. Go goroutines can run on any OS thread,
+	// so ensure COM is initialized on the current one before making COM calls.
+	C.CoInitializeEx(nil, C.COINIT_MULTITHREADED)
+
 	c.ch = make(chan []byte)
 	c.cam = &C.camera{
 		name: C.CString(c.name),
@@ -128,6 +132,8 @@ func (c *camera) Close() error {
 }
 
 func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
+	C.CoInitializeEx(nil, C.COINIT_MULTITHREADED)
+
 	nPix := p.Width * p.Height
 	c.buf = make([]byte, nPix*2)
 	c.bufGo = make([]byte, nPix*2)

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -25,9 +25,18 @@ var (
 )
 
 type camera struct {
-	name  string
-	cam   *C.camera
-	ch    chan []byte
+	name string
+	// mu protects cam, closed, and the fields they gate.
+	mu  sync.Mutex
+	cam *C.camera
+	// closed guards against double closing.
+	closed bool
+
+	// ch delivers decoded frame data from the DirectShow callback to the Go reader.
+	ch chan []byte
+	// done is closed on Close() to unblock any in-flight imageCallback send.
+	done chan struct{}
+
 	buf   []byte
 	bufGo []byte
 }
@@ -87,7 +96,12 @@ func (c *camera) Open() error {
 	// so ensure COM is initialized on the current one before making COM calls.
 	C.CoInitializeEx(nil, C.COINIT_MULTITHREADED)
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.ch = make(chan []byte)
+	c.done = make(chan struct{})
+	c.closed = false
 	c.cam = &C.camera{
 		name: C.CString(c.name),
 	}
@@ -95,6 +109,7 @@ func (c *camera) Open() error {
 	var errStr *C.char
 	if C.listResolution(c.cam, &errStr) != 0 {
 		C.free(unsafe.Pointer(c.cam.name))
+		c.cam = nil
 		return fmt.Errorf("failed to open device: %s", C.GoString(errStr))
 	}
 
@@ -111,23 +126,36 @@ func imageCallback(cam uintptr) {
 	}
 
 	copy(cb.bufGo, cb.buf)
-	cb.ch <- cb.bufGo
+	select {
+	case cb.ch <- cb.bufGo:
+	case <-cb.done:
+	}
 }
 
 func (c *camera) Close() error {
-	callbacksMu.Lock()
-	key := uintptr(unsafe.Pointer(c.cam))
-	if _, ok := callbacks[key]; ok {
-		delete(callbacks, key)
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
 	}
-	callbacksMu.Unlock()
-	close(c.ch)
+	c.closed = true
+	cam := c.cam
+	c.cam = nil
+	c.mu.Unlock()
 
-	if c.cam != nil {
-		C.free(unsafe.Pointer(c.cam.name))
-		C.freeCamera(c.cam)
-		c.cam = nil
+	// Remove from callbacks map so no new imageCallback calls find this cam
+	callbacksMu.Lock()
+	delete(callbacks, uintptr(unsafe.Pointer(cam)))
+	callbacksMu.Unlock()
+
+	close(c.done)
+
+	if cam != nil {
+		C.free(unsafe.Pointer(cam.name))
+		C.freeCamera(cam)
 	}
+
+	close(c.ch)
 	return nil
 }
 
@@ -190,9 +218,15 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 }
 
 func (c *camera) Properties() []prop.Media {
+	c.mu.Lock()
+	cam := c.cam
+	c.mu.Unlock()
+	if cam == nil {
+		return nil
+	}
 	properties := []prop.Media{}
-	for i := 0; i < int(c.cam.numProps); i++ {
-		p := C.getProp(c.cam, C.int(i))
+	for i := 0; i < int(cam.numProps); i++ {
+		p := C.getProp(cam, C.int(i))
 		var fmt frame.Format
 		switch p.fcc {
 		case fourccYUY2:

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -33,8 +33,9 @@ type camera struct {
 	ch     chan []byte
 	done   chan struct{}
 
-	buf   []byte
-	bufGo []byte
+	cbuf   unsafe.Pointer // C.malloc'd buffer for DirectShow writes
+	bufLen int            // byte length of cbuf
+	bufGo  []byte
 }
 
 func init() {
@@ -125,7 +126,7 @@ func imageCallback(cam uintptr) {
 		return
 	}
 
-	copy(cb.bufGo, cb.buf)
+	copy(cb.bufGo, unsafe.Slice((*byte)(cb.cbuf), cb.bufLen))
 	select {
 	case cb.ch <- cb.bufGo:
 	case <-cb.done:
@@ -141,6 +142,8 @@ func (c *camera) Close() error {
 	c.closed = true
 	cam := c.cam
 	c.cam = nil
+	cbuf := c.cbuf
+	c.cbuf = nil
 	done := c.done
 	ch := c.ch
 	c.mu.Unlock()
@@ -159,6 +162,8 @@ func (c *camera) Close() error {
 		C.freeCamera(cam)
 	}
 
+	C.free(cbuf)
+
 	if ch != nil {
 		close(ch)
 	}
@@ -176,8 +181,13 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 	}
 
 	nPix := p.Width * p.Height
-	c.buf = make([]byte, nPix*2)
-	c.bufGo = make([]byte, nPix*2)
+	bufSize := nPix * 2
+	c.cbuf = C.malloc(C.size_t(bufSize))
+	if c.cbuf == nil {
+		return nil, fmt.Errorf("failed to allocate frame buffer")
+	}
+	c.bufLen = bufSize
+	c.bufGo = make([]byte, bufSize)
 	c.cam.width = C.int(p.Width)
 	c.cam.height = C.int(p.Height)
 
@@ -188,10 +198,12 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 		c.cam.fcc = fourccYUY2
 	}
 
-	c.cam.buf = C.size_t(uintptr(unsafe.Pointer(&c.buf[0])))
+	c.cam.buf = C.size_t(uintptr(c.cbuf))
 
 	var errStr *C.char
 	if C.openCamera(c.cam, &errStr) != 0 {
+		C.free(c.cbuf)
+		c.cbuf = nil
 		return nil, fmt.Errorf("failed to open device: %s", C.GoString(errStr))
 	}
 

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -26,7 +26,7 @@ var (
 
 type camera struct {
 	name string
-	// mu protects fields under as per the mutex hat pattern
+	// mu protects the fields under as per the mutex hat convention.
 	mu     sync.Mutex
 	cam    *C.camera
 	closed bool
@@ -141,6 +141,8 @@ func (c *camera) Close() error {
 	c.closed = true
 	cam := c.cam
 	c.cam = nil
+	done := c.done
+	ch := c.ch
 	c.mu.Unlock()
 
 	// Remove from callbacks map so no new imageCallback calls find this cam
@@ -148,19 +150,30 @@ func (c *camera) Close() error {
 	delete(callbacks, uintptr(unsafe.Pointer(cam)))
 	callbacksMu.Unlock()
 
-	close(c.done)
+	if done != nil {
+		close(done)
+	}
 
 	if cam != nil {
 		C.free(unsafe.Pointer(cam.name))
 		C.freeCamera(cam)
 	}
 
-	close(c.ch)
+	if ch != nil {
+		close(ch)
+	}
 	return nil
 }
 
 func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 	C.CoInitializeEx(nil, C.COINIT_MULTITHREADED)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cam == nil {
+		return nil, fmt.Errorf("camera not open")
+	}
 
 	nPix := p.Width * p.Height
 	c.buf = make([]byte, nPix*2)

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -26,16 +26,12 @@ var (
 
 type camera struct {
 	name string
-	// mu protects cam, closed, and the fields they gate.
-	mu  sync.Mutex
-	cam *C.camera
-	// closed guards against double closing.
+	// mu protects fields under as per the mutex hat pattern
+	mu     sync.Mutex
+	cam    *C.camera
 	closed bool
-
-	// ch delivers decoded frame data from the DirectShow callback to the Go reader.
-	ch chan []byte
-	// done is closed on Close() to unblock any in-flight imageCallback send.
-	done chan struct{}
+	ch     chan []byte
+	done   chan struct{}
 
 	buf   []byte
 	bufGo []byte
@@ -98,6 +94,10 @@ func (c *camera) Open() error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.cam != nil {
+		return fmt.Errorf("camera already open")
+	}
 
 	c.ch = make(chan []byte)
 	c.done = make(chan struct{})
@@ -219,14 +219,13 @@ func (c *camera) VideoRecord(p prop.Media) (video.Reader, error) {
 
 func (c *camera) Properties() []prop.Media {
 	c.mu.Lock()
-	cam := c.cam
-	c.mu.Unlock()
-	if cam == nil {
+	defer c.mu.Unlock()
+	if c.cam == nil {
 		return nil
 	}
 	properties := []prop.Media{}
-	for i := 0; i < int(cam.numProps); i++ {
-		p := C.getProp(cam, C.int(i))
+	for i := 0; i < int(c.cam.numProps); i++ {
+		p := C.getProp(c.cam, C.int(i))
 		var fmt frame.Format
 		switch p.fcc {
 		case fourccYUY2:

--- a/pkg/driver/camera/camera_windows.go
+++ b/pkg/driver/camera/camera_windows.go
@@ -121,12 +121,13 @@ func (c *camera) Open() error {
 func imageCallback(cam uintptr) {
 	callbacksMu.RLock()
 	cb, ok := callbacks[uintptr(unsafe.Pointer(cam))]
-	callbacksMu.RUnlock()
 	if !ok {
+		callbacksMu.RUnlock()
 		return
 	}
-
 	copy(cb.bufGo, unsafe.Slice((*byte)(cb.cbuf), cb.bufLen))
+	callbacksMu.RUnlock()
+
 	select {
 	case cb.ch <- cb.bufGo:
 	case <-cb.done:


### PR DESCRIPTION
## Summary

- **Per-thread COM initialization**: `CoInitializeEx` was only called once in `init()`. Go goroutines can run on any OS thread, so `Open()` and `VideoRecord()` now call `CoInitializeEx` on their current thread before making COM calls. `COINIT_MULTITHREADED` is idempotent so repeated calls are safe.
- **Mutex and idempotent Close**: Added `sync.Mutex` protecting shared camera state (`cam`, `closed`, `ch`, `done`) to prevent races between concurrent `Open`/`Close`/`VideoRecord`/`Properties` calls. `Close` snapshots fields under the lock, nils them out, then tears down outside the lock. Double close is a no-op.
- **Done channel for callback unblock**: `imageCallback` previously did a blocking send on `ch`. If no reader was consuming, this blocked the DirectShow streaming thread forever. Added a `done` channel to the select so `Close` can unblock it.
- **C-allocated frame buffer**: The DirectShow `BufferCB` callback writes into a frame buffer from a non-Go thread. Previously this buffer was a Go heap slice whose backing array the GC could relocate, causing silent memory corruption. Now allocated with `C.malloc` and freed explicitly in `Close`.
- **C++ bugfixes**: Fixed `delete cam->props` to `delete[] cam->props` (mismatched new[]/delete). Removed unused `LPOLESTR name` variable in `listResolution`.

Stacked on top of https://github.com/pion/mediadevices/pull/683