### PR TITLE
feat(vpx): expose libvpx g_threads as Params.EncodingThreads

### DIFF
--- a/pkg/codec/vpx/params.go
+++ b/pkg/codec/vpx/params.go
@@ -18,6 +18,11 @@ type Params struct {
 	RateControlMaxQuantizer      uint
 	LagInFrames                  uint
 	ErrorResilient               ErrorResilientMode
+	// EncodingThreads sets libvpx's g_threads. 0 leaves the libvpx default
+	// (single-thread). Multi-threaded encoding can substantially improve
+	// throughput on multi-core hosts; the effective ceiling depends on
+	// resolution and codec (VP8 typically benefits up to ~4 threads, VP9 more).
+	EncodingThreads uint
 }
 
 // RateControlMode represents rate control mode.

--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -156,6 +156,7 @@ func newParams(codecIface *C.vpx_codec_iface_t) (Params, error) {
 		RateControlMaxQuantizer:      uint(cfg.rc_max_quantizer),
 		LagInFrames:                  uint(cfg.g_lag_in_frames),
 		ErrorResilient:               ErrorResilientMode(cfg.g_error_resilient),
+		EncodingThreads:              uint(cfg.g_threads),
 	}, nil
 }
 
@@ -188,6 +189,9 @@ func newEncoder(r video.Reader, p prop.Media, params Params, codecIface *C.vpx_c
 	cfg.g_lag_in_frames = C.uint(params.LagInFrames)
 	cfg.rc_target_bitrate = C.uint(params.BitRate) / 1000
 	cfg.kf_max_dist = C.uint(params.KeyFrameInterval)
+	if params.EncodingThreads > 0 {
+		cfg.g_threads = C.uint(params.EncodingThreads)
+	}
 
 	cfg.rc_resize_allowed = 0
 	cfg.g_pass = C.VPX_RC_ONE_PASS

--- a/pkg/codec/vpx/vpx_test.go
+++ b/pkg/codec/vpx/vpx_test.go
@@ -312,6 +312,35 @@ func TestShouldImplementBitRateControl(t *testing.T) {
 	}
 }
 
+func TestEncodingThreadsBuilds(t *testing.T) {
+	// Smoke-test that Params.EncodingThreads is plumbed to cfg.g_threads.
+	// Setting >0 must produce a working encoder; default (0) leaves libvpx's
+	// own default in place.
+	for name, threads := range map[string]uint{
+		"Default": 0,
+		"Four":    4,
+	} {
+		t.Run(name, func(t *testing.T) {
+			p, err := NewVP8Params()
+			if err != nil {
+				t.Fatal(err)
+			}
+			p.BitRate = 100000
+			p.EncodingThreads = threads
+			enc, err := p.BuildVideoEncoder(
+				video.ReaderFunc(func() (image.Image, func(), error) {
+					return image.NewYCbCr(image.Rect(0, 0, 64, 64), image.YCbCrSubsampleRatio420), func() {}, nil
+				}),
+				prop.Media{Video: prop.Video{Width: 64, Height: 64, FrameRate: 30}},
+			)
+			if err != nil {
+				t.Fatalf("BuildVideoEncoder failed with EncodingThreads=%d: %v", threads, err)
+			}
+			assert.NoError(t, enc.Close())
+		})
+	}
+}
+
 func TestShouldImplementKeyFrameControl(t *testing.T) {
 	e := &encoder{}
 	if _, ok := e.Controller().(codec.KeyFrameController); !ok {


### PR DESCRIPTION
## Summary

VP8/VP9 encoders run single-threaded today because libvpx's `g_threads` is never set after the default. Multi-threaded encoding is a substantial throughput improvement on multi-core hosts — VP8 typically benefits up to ~4 threads at common resolutions, VP9 more.

Adds `Params.EncodingThreads` (uint). Zero (default) preserves libvpx's existing single-thread behavior so existing callers see no change. Set to >0 to opt in:

```go
p, _ := vpx.NewVP8Params()
p.EncodingThreads = 4
encoder, _ := p.BuildVideoEncoder(reader, props)
```

Symmetric with the rest of `Params`: `newParams()` also reports the libvpx default back via the field.

## Why this exists out-of-tree already

Surfaced while migrating a downstream service that had been carrying this exact patch on a private fork. The patch is small, the API addition is additive + backward-compatible, and there's no good way to set `g_threads` from outside the package today. Upstreaming saves the fork.

## Test plan

- [x] `go test -count=1 -run TestEncodingThreadsBuilds ./pkg/codec/vpx/` passes
- [x] `go test -count=1 ./pkg/codec/vpx/` (full vpx suite) passes
- [x] `go vet ./pkg/codec/vpx/` clean

New `TestEncodingThreadsBuilds` covers both default (0 → libvpx default) and an opt-in value (4) — verifies the encoder builds + closes cleanly under both.

## Backward compatibility

`EncodingThreads` defaults to 0, which is explicitly guarded:

```go
if params.EncodingThreads > 0 {
    cfg.g_threads = C.uint(params.EncodingThreads)
}
```

Existing callers that never set the field see `cfg.g_threads` left at whatever `vpx_codec_enc_config_default` returns (1 in current libvpx) — i.e. no behavior change.