### PR TITLE
codec/vpx: clamp encoder frame duration to recover from long idle gaps

### DIFF
--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -271,8 +271,30 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	// and consequently the codec will read the first frame from the buffer. This means the first frame won't
 	// have a pause to the second frame, which means if the delay is <1 ms (vpx duration resolution), duration
 	// is going to be 0.
-	if duration == 0 {
+	//
+	// Also clamp implausibly large durations. tLastFrame is only updated after a successful encode, so when
+	// an encoder sits idle for a long time (waiting for a remote subscriber, paused upstream, etc.) the next
+	// frame's duration can exceed UINT32_MAX microseconds. libvpx 1.15.0+ rejects any duration strictly
+	// greater than UINT32_MAX with VPX_CODEC_INVALID_PARAM — see libvpx/vpx/src/vpx_encoder.c:206 (added in
+	// libvpx commit 7fb8ceccf, "Restrict ranges of duration,deadline to UINT32_MAX", 2024-03-14):
+	//
+	//   else if (duration > UINT32_MAX || deadline > UINT32_MAX)
+	//       res = VPX_CODEC_INVALID_PARAM;
+	//
+	// UINT32_MAX microseconds is about 71m35s, so any encoder idle for longer than that fails its next
+	// encode. Older libvpx (≤ 1.14.x) silently accepted huge durations, which is why this surfaced as a
+	// new failure mode after a libvpx upgrade to 1.15+. Once the error fires, the failure path below also
+	// does not update tLastFrame, so every subsequent encode sees an even larger duration and fails
+	// identically — the encoder is permanently unusable until recreated.
+	//
+	// Substituting a sane synthetic frame interval keeps the encoder healthy across idle gaps; pts
+	// continues monotonically from tStart so libvpx's internal pts ordering remains correct.
+	const maxFrameDurationUs = 1_000_000   // 1s — well below libvpx 1.15+'s UINT32_MAX μs (~71 min) limit
+	const fallbackFrameDurationUs = 33_333 // ~30fps frame interval, a sensible "this is a fresh frame"
+	if duration <= 0 {
 		duration = 1
+	} else if duration > maxFrameDurationUs {
+		duration = fallbackFrameDurationUs
 	}
 
 	targetVpxBitrate := C.uint(float32(e.targetBitrate / 1000)) // convert to kilobits / second

--- a/pkg/codec/vpx/vpx_test.go
+++ b/pkg/codec/vpx/vpx_test.go
@@ -365,6 +365,94 @@ func TestEncoderFrameMonotonic(t *testing.T) {
 	}
 }
 
+// TestEncoderHandlesLongIdleGap verifies the duration clamp in the Read()
+// path. When an encoder sits idle for a long time (no frames arriving from
+// the source, so vpx_codec_encode is never called and tLastFrame stays at
+// encoder-creation time), the next frame would otherwise be encoded with
+// `duration = t.Sub(tLastFrame).Microseconds()` — a value potentially in
+// the trillions of microseconds.
+//
+// libvpx 1.15.0+ explicitly rejects any duration > UINT32_MAX with
+// VPX_CODEC_INVALID_PARAM at vpx/src/vpx_encoder.c:206 (added in libvpx
+// commit 7fb8ceccf, 2024-03-14). UINT32_MAX μs is about 71m35s, so any
+// encoder idle longer than that fails its next encode. Because the failure
+// path inside Read() does not refresh tLastFrame, every subsequent frame
+// sees an even larger duration and fails identically — the encoder becomes
+// permanently unusable until recreated.
+//
+// The clamp in Read() substitutes a sane synthetic frame interval when the
+// computed duration exceeds maxFrameDurationUs, keeping the encoder usable
+// across idle gaps of arbitrary length.
+func TestEncoderHandlesLongIdleGap(t *testing.T) {
+	params, err := NewVP8Params()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rcloser, err := params.BuildVideoEncoder(
+		video.ReaderFunc(func() (image.Image, func(), error) {
+			return image.NewYCbCr(
+				image.Rect(0, 0, 320, 240),
+				image.YCbCrSubsampleRatio420,
+			), func() {}, nil
+		},
+		), prop.Media{
+			Video: prop.Video{
+				Width:       320,
+				Height:      240,
+				FrameRate:   30,
+				FrameFormat: frame.FormatI420,
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rcloser.Close()
+
+	e, ok := rcloser.(*encoder)
+	if !ok {
+		t.Fatalf("expected *encoder, got %T", rcloser)
+	}
+
+	// Simulate an encoder that has sat idle since creation. tStart and
+	// tLastFrame are both rewound, mirroring the production sequence where
+	// the encoder waited hours for a remote subscriber before its first
+	// frame arrived.
+	e.mu.Lock()
+	const idleDuration = 6 * time.Hour
+	e.tStart = e.tStart.Add(-idleDuration)
+	e.tLastFrame = e.tLastFrame.Add(-idleDuration)
+	tLastFrameBefore := e.tLastFrame
+	e.mu.Unlock()
+
+	// First encode after the idle gap must succeed.
+	if _, rel, err := rcloser.Read(); err != nil {
+		t.Fatalf("encode after long idle gap failed: %v", err)
+	} else {
+		rel()
+	}
+
+	// tLastFrame must be refreshed so subsequent frames see a normal-sized
+	// duration. The bug's permanence stemmed from tLastFrame staying stale
+	// on the failure path.
+	e.mu.Lock()
+	tLastFrameAfter := e.tLastFrame
+	e.mu.Unlock()
+	if !tLastFrameAfter.After(tLastFrameBefore) {
+		t.Fatalf("tLastFrame not refreshed after encode (before=%v after=%v)",
+			tLastFrameBefore, tLastFrameAfter)
+	}
+
+	// Subsequent encodes must continue working.
+	for i := 0; i < 3; i++ {
+		if _, rel, err := rcloser.Read(); err != nil {
+			t.Fatalf("encode %d after recovery failed: %v", i, err)
+		} else {
+			rel()
+		}
+	}
+}
+
 func TestVP8DynamicQPControl(t *testing.T) {
 	t.Run("VP8", func(t *testing.T) {
 		p, err := NewVP8Params()


### PR DESCRIPTION
## Problem

`encoder.Read()` in `pkg/codec/vpx/vpx.go` computes the frame duration as:

```go
duration := t.Sub(e.tLastFrame).Microseconds()
```

`tLastFrame` is only refreshed after a successful `vpx_codec_encode`. When an encoder sits idle (no frames from the source — e.g. waiting for a remote subscriber, paused upstream, or `ErrNoFrameAvailable` from a non-blocking source), `Read()` returns early before `vpx_codec_encode` is called and `tLastFrame` is never updated.

When a frame finally arrives, `duration` can be many hours' worth of microseconds. **libvpx 1.15.0+ explicitly rejects any `duration > UINT32_MAX`** at `vpx/src/vpx_encoder.c:206-207`:

```c
else if (duration > UINT32_MAX || deadline > UINT32_MAX)
    res = VPX_CODEC_INVALID_PARAM;
```

This check was added in libvpx commit [7fb8ceccf](https://github.com/webmproject/libvpx/commit/7fb8ceccf) ("Restrict ranges of duration,deadline to UINT32_MAX", 2024-03-14, first released in v1.15.0). `UINT32_MAX` microseconds is about **71m35s**, so any encoder idle longer than that fails its next `vpx_codec_encode` with `VPX_CODEC_INVALID_PARAM` (error code 8).

Older libvpx (≤ 1.14.x) silently accepted huge durations, so this surfaced as a new failure mode after upgrading. The failure inside `Read()` also does not update `tLastFrame`, so every subsequent encode sees an even larger duration and fails identically — the encoder becomes permanently unusable until recreated.

We hit this in production on a vehicle teleoperation use case (multi-hour wait for a subscriber to connect after the publisher starts) running libvpx 1.16.0. A separate workaround in [pion/bwe-test](https://github.com/pion/bwe-test) (commit 43a3057, `recreateEncodersForActivatedTracks` triggered on bitrate-allocation transitions) addresses one trigger path but misses others — anything that produces the same idle gap with constant non-zero allocation isn't covered. Fixing it at the encoder layer covers all entry points uniformly.

## Fix

Clamp the computed `duration` to `maxFrameDurationUs` (1 s). If exceeded, substitute `fallbackFrameDurationUs` (~30 fps frame interval). `pts` continues to be computed from `tStart`, so libvpx's internal pts ordering remains monotonically correct — only the per-frame `duration` argument is substituted.

The existing `duration == 0` guard is widened to `duration <= 0` for symmetry.

## Test

`TestEncoderHandlesLongIdleGap` rewinds the encoder's `tStart` / `tLastFrame` by 6 hours (5x past the UINT32_MAX us threshold) and verifies:

1. The first encode after the synthetic idle gap succeeds.
2. `tLastFrame` is refreshed (so subsequent frames see a normal-sized duration).
3. Three subsequent encodes continue to succeed.

Reproduced locally on libvpx 1.16.0 (built from source). Without the clamp the test fails with `vpx_codec_encode failed (8)` — exact match for the production error. With the clamp the test passes. On libvpx 1.8.2 (default Ubuntu package) the bug does not reproduce, confirming the failure is specific to the 1.15+ UINT32_MAX check.
