### PR TITLE
codec/vpx: surface libvpx err_detail in returned errors

### DIFF
--- a/pkg/codec/vpx/vpx.go
+++ b/pkg/codec/vpx/vpx.go
@@ -47,6 +47,18 @@ package vpx
 //   raw->planes[0] = raw->planes[1] = raw->planes[2] = 0;
 //   return ret;
 // }
+//
+// // NULL-safe wrapper around vpx_codec_error_detail. libvpx sets err_detail
+// // inside its ERROR(...) macro (e.g. vp8_cx_iface.c:108-112) with the
+// // specific reason for failures like VPX_CODEC_INVALID_PARAM, but the field
+// // is NULL when no detail is available. Returning an empty C string in that
+// // case keeps the Go side simple.
+// const char *error_detail_safe(vpx_codec_ctx_t *ctx) {
+//   if (ctx == NULL) return "";
+//   const char *d = vpx_codec_error_detail(ctx);
+//   if (d == NULL) return "";
+//   return d;
+// }
 import "C"
 
 import (
@@ -204,7 +216,7 @@ func newEncoder(r video.Reader, p prop.Media, params Params, codecIface *C.vpx_c
 	if ec := C.vpx_codec_enc_init_ver(
 		codec, codecIface, cfg, 0, C.VPX_ENCODER_ABI_VERSION,
 	); ec != 0 {
-		return nil, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
+		return nil, fmt.Errorf("vpx_codec_enc_init failed (%d): %s", ec, C.GoString(C.error_detail_safe(codec)))
 	}
 	t0 := time.Now()
 	return &encoder{
@@ -251,7 +263,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 		if ec := C.vpx_codec_enc_init_ver(
 			newCodec, e.codec.iface, e.cfg, 0, C.VPX_ENCODER_ABI_VERSION,
 		); ec != 0 {
-			return nil, func() {}, fmt.Errorf("vpx_codec_enc_init failed (%d)", ec)
+			return nil, func() {}, fmt.Errorf("vpx_codec_enc_init failed (%d): %s", ec, C.GoString(C.error_detail_safe(newCodec)))
 		}
 		C.free(unsafe.Pointer(e.codec))
 		e.codec = newCodec
@@ -262,7 +274,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 	}
 
 	if ec := C.vpx_codec_enc_config_set(e.codec, e.cfg); ec != 0 {
-		return nil, func() {}, fmt.Errorf("vpx_codec_enc_config_set failed (%d)", ec)
+		return nil, func() {}, fmt.Errorf("vpx_codec_enc_config_set failed (%d): %s", ec, C.GoString(C.error_detail_safe(e.codec)))
 	}
 
 	duration := t.Sub(e.tLastFrame).Microseconds()
@@ -280,7 +292,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 		e.cfg.rc_target_bitrate = targetVpxBitrate
 		rc := C.vpx_codec_enc_config_set(e.codec, e.cfg)
 		if rc != C.VPX_CODEC_OK {
-			return nil, func() {}, fmt.Errorf("vpx_codec_enc_config_set failed (%d)", rc)
+			return nil, func() {}, fmt.Errorf("vpx_codec_enc_config_set failed (%d): %s", rc, C.GoString(C.error_detail_safe(e.codec)))
 		}
 	}
 
@@ -293,7 +305,7 @@ func (e *encoder) Read() ([]byte, func(), error) {
 		C.long(t.Sub(e.tStart).Microseconds()), C.ulong(duration), C.long(flags), C.ulong(e.deadline),
 		(*C.uchar)(&yuvImg.Y[0]), (*C.uchar)(&yuvImg.Cb[0]), (*C.uchar)(&yuvImg.Cr[0]),
 	); ec != C.VPX_CODEC_OK {
-		return nil, func() {}, fmt.Errorf("vpx_codec_encode failed (%d)", ec)
+		return nil, func() {}, fmt.Errorf("vpx_codec_encode failed (%d): %s", ec, C.GoString(C.error_detail_safe(e.codec)))
 	}
 
 	e.requireKeyFrame = false

--- a/pkg/codec/vpx/vpx_test.go
+++ b/pkg/codec/vpx/vpx_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -303,6 +304,80 @@ func TestSetBitrate(t *testing.T) {
 		})
 
 	}
+}
+
+// TestEncodeErrorIncludesDetail verifies that when vpx_codec_encode returns
+// a non-OK code, the Go error message includes libvpx's err_detail string
+// (set inside libvpx's ERROR(...) macro). This is the field that holds the
+// specific reason for VPX_CODEC_INVALID_PARAM and similar errors.
+//
+// We trigger the failure deterministically by reaching into the encoder
+// after the first successful encode and forcing a size mismatch between
+// e.raw (the vpx_image_t the encoder hands to vpx_codec_encode) and the
+// encoder cfg's expected dimensions. libvpx's validate_img() rejects this
+// with "Image size must match encoder init configuration size" via the
+// ERROR macro and returns VPX_CODEC_INVALID_PARAM. With this change, the
+// Go error wraps that detail string so oncall/operator-side logs can see
+// the specific cause instead of a bare error code.
+func TestEncodeErrorIncludesDetail(t *testing.T) {
+	p, err := NewVP8Params()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := p.BuildVideoEncoder(
+		video.ReaderFunc(func() (image.Image, func(), error) {
+			return image.NewYCbCr(image.Rect(0, 0, 320, 240), image.YCbCrSubsampleRatio420), func() {}, nil
+		}),
+		prop.Media{
+			Video: prop.Video{
+				Width:       320,
+				Height:      240,
+				FrameRate:   1,
+				FrameFormat: frame.FormatI420,
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	// First read succeeds and initializes libvpx with cfg.g_w/g_h = 320/240.
+	if _, rel, err := r.Read(); err != nil {
+		t.Fatalf("first read should succeed: %v", err)
+	} else {
+		rel()
+	}
+
+	// Force a size mismatch inside the encoder by mutating e.raw's display
+	// dimensions to disagree with e.cfg. The Read() path doesn't touch d_w/d_h
+	// unless image dimensions change (which they won't here), so the corrupt
+	// e.raw flows directly into vpx_codec_encode and triggers validate_img.
+	e := r.(*encoder)
+	e.mu.Lock()
+	e.raw.d_w = 100
+	e.raw.d_h = 100
+	e.mu.Unlock()
+
+	_, _, err = r.Read()
+	if err == nil {
+		t.Skip("forced mismatch unexpectedly succeeded — libvpx tolerant on this build")
+	}
+	t.Logf("error: %v", err)
+	if !strings.Contains(err.Error(), "vpx_codec_encode failed") {
+		t.Fatalf("unexpected error shape: %v", err)
+	}
+	// The new error shape is "vpx_codec_encode failed (N): <detail>"; we
+	// require the colon-detail suffix is present. The detail itself
+	// (libvpx's err_detail) should be non-empty for this size-mismatch path.
+	if !strings.Contains(err.Error(), "): ") {
+		t.Fatalf("error missing detail suffix; expected `(N): <detail>` shape, got: %v", err)
+	}
+	suffix := err.Error()[strings.Index(err.Error(), "): ")+3:]
+	if suffix == "" {
+		t.Fatalf("err_detail is empty; expected libvpx to set it for the size-mismatch path")
+	}
+	t.Logf("extracted libvpx err_detail: %q", suffix)
 }
 
 func TestShouldImplementBitRateControl(t *testing.T) {


### PR DESCRIPTION
libvpx sets a human-readable reason string via its ERROR(...) macro for every error path that returns VPX_CODEC_INVALID_PARAM and similar codes (see vp8/vp8_cx_iface.c). The reason can be retrieved via the public vpx_codec_error_detail() API. The pion wrapper currently surfaces only the integer error code, which makes it very hard to diagnose "vpx_codec_encode failed (8)" / "(1)" / etc. from logs — INVALID_PARAM alone can mean image-size mismatch, out-of-range cfg field, monotonicity violation, or various other things, and a downstream operator hitting the error has no way to tell which.

Add a NULL-safe C wrapper around vpx_codec_error_detail and append the returned string (or empty) to the four error sites in encoder.Read() and the one in newEncoder(). The error format changes from

    vpx_codec_encode failed (8)

to

    vpx_codec_encode failed (8): Image size must match encoder init configuration size

Test:

TestEncodeErrorIncludesDetail deterministically triggers VPX_CODEC_INVALID_PARAM by mutating e.raw.d_w/d_h after the first encode (libvpx's validate_img then rejects the next call) and asserts that the returned error contains a non-empty err_detail suffix matching the new "(N): <detail>" shape.

Motivation:

We hit an unexplained VPX_CODEC_INVALID_PARAM cascade in production on a vehicle running this encoder for 14 simultaneous camera tracks after a long idle period followed by streaming activation. With only "(8)" in the log, we cannot tell whether it's the image-size check, the pts ordering check, a rate-control range check, or something else. This patch unblocks that diagnosis going forward without changing any control-flow behavior.

#### Description

#### Reference issue
Fixes #...
